### PR TITLE
Update token response to include setting auth properties as environment variables

### DIFF
--- a/galasa-ui/src/components/PageHeader.tsx
+++ b/galasa-ui/src/components/PageHeader.tsx
@@ -11,7 +11,7 @@ export default function PageHeader() {
   return (
     <Header aria-label="Galasa Ecosystem">
       <SkipToContent />
-      <HeaderName prefix="Galasa Ecosystem">(Experimental)</HeaderName>
+      <HeaderName prefix="">Galasa Ecosystem</HeaderName>
     </Header>
   );
 };

--- a/galasa-ui/src/components/TokenResponseModal.tsx
+++ b/galasa-ui/src/components/TokenResponseModal.tsx
@@ -45,8 +45,8 @@ export default function TokenResponseModal({ refreshToken, clientId, clientSecre
       }}
     >
       <p>
-        Copy the following properties into the galasactl.properties file in your Galasa home directory* to allow your client tool to access the Galasa
-        Ecosystem.
+        Copy the following properties into the galasactl.properties file in your Galasa home directory* or set them as environment variables in your
+        terminal to allow your client tool to access the Galasa Ecosystem.
       </p>
       <CodeSnippet type="multi">
         {`GALASA_ACCESS_TOKEN=${token}

--- a/galasa-ui/src/tests/__snapshots__/index.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/index.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`renders Galasa Ecosystem homepage 1`] = `
               id="cds--modal-body--modal-2"
             >
               <p>
-                Copy the following properties into the galasactl.properties file in your Galasa home directory* to allow your client tool to access the Galasa Ecosystem.
+                Copy the following properties into the galasactl.properties file in your Galasa home directory* or set them as environment variables in your terminal to allow your client tool to access the Galasa Ecosystem.
               </p>
               <div
                 class="cds--snippet cds--snippet--multi"
@@ -572,7 +572,7 @@ GALASA_SECRET=
             id="cds--modal-body--modal-2"
           >
             <p>
-              Copy the following properties into the galasactl.properties file in your Galasa home directory* to allow your client tool to access the Galasa Ecosystem.
+              Copy the following properties into the galasactl.properties file in your Galasa home directory* or set them as environment variables in your terminal to allow your client tool to access the Galasa Ecosystem.
             </p>
             <div
               class="cds--snippet cds--snippet--multi"

--- a/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
@@ -32,13 +32,7 @@ exports[`Layout renders the web UI layout 1`] = `
             <a
               class="cds--header__name"
             >
-              <span
-                class="cds--header__name--prefix"
-              >
-                Galasa Ecosystem
-              </span>
-               
-              (Experimental)
+              Galasa Ecosystem
             </a>
           </header>
           Hello, world!
@@ -74,13 +68,7 @@ exports[`Layout renders the web UI layout 1`] = `
           <a
             class="cds--header__name"
           >
-            <span
-              class="cds--header__name--prefix"
-            >
-              Galasa Ecosystem
-            </span>
-             
-            (Experimental)
+            Galasa Ecosystem
           </a>
         </header>
         Hello, world!


### PR DESCRIPTION
Related to https://github.com/galasa-dev/projectmanagement/issues/1713

- Updated token response text to also tell users that they can set the displayed properties as environment variables
- Removed "Experimental" from the webui header