### PR TITLE
Upgrade version of open api bundle for webui

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaFrameworkVersion = '0.34.0'
+def galasaFrameworkVersion = '0.34.1'
 def galasaOpenApiYamlVersion = galasaFrameworkVersion
 
 repositories {


### PR DESCRIPTION
### Why?
See [Release v0.34.0 and v0.34.1 #1827](https://github.com/galasa-dev/projectmanagement/issues/1827)

The dev.galasa.framework.api.openapi bundle has been upgraded to 0.34.1 so this reflects that.

- The webui build phase creates a java client for the openapi REST interface. It pulls the openapi.yaml down from the maven repo.
- Then it doesn't need it after that once the java client is built.
- As the REST interface didn't change between 0.34 and 0.34.1 then it probably doesn't matter, but this seems sensible to bump it.
