### PR TITLE
Fix default markdown, add set-version script, add basic linting rules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaFrameworkVersion = '0.37.0'
+def galasaFrameworkVersion = "0.38.0"
 def galasaOpenApiYamlVersion = galasaFrameworkVersion
 
 repositories {

--- a/dockerfiles/dockerfile.webui
+++ b/dockerfiles/dockerfile.webui
@@ -13,6 +13,7 @@ RUN chown -R node:node /galasa
 # Take advantage of Next.js' automatic file tracing to reduce image size
 # See https://nextjs.org/docs/app/api-reference/next-config-js/output for information.
 COPY --chown=node:node ./galasa-ui/.next/standalone ./
+COPY --chown=node:node ./galasa-ui/public ./public
 COPY --chown=node:node ./galasa-ui/.next/static ./.next/static
 
 # Never run anything in a docker container as the root user if you can help it.

--- a/galasa-ui/.eslintrc.json
+++ b/galasa-ui/.eslintrc.json
@@ -1,3 +1,9 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "ignorePatterns": ["**/generated/*"],
+  "rules": {
+    "indent": ["error", 2],
+    "semi": "error",
+    "no-irregular-whitespace": "error"
+  }
 }

--- a/galasa-ui/src/app/auth/tokens/route.ts
+++ b/galasa-ui/src/app/auth/tokens/route.ts
@@ -9,7 +9,7 @@ import AuthCookies from '@/utils/authCookies';
 import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 import { AuthenticationAPIApi, UsersAPIApi } from '@/generated/galasaapi';
-import * as Constants from "@/utils/constants"
+import * as Constants from "@/utils/constants";
 
 // Stop this route from being pre-rendered
 export const dynamic = 'force-dynamic';
@@ -23,7 +23,7 @@ interface TokenDetails {
 export async function POST(request: NextRequest) {
   // Call out to the API server's /auth/clients endpoint to create a new Dex client
 
-  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration())
+  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration());
   const dexClient = await authApiClientWithAuthHeader.postClients();
 
   const clientId = dexClient.clientId;
@@ -40,7 +40,7 @@ export async function POST(request: NextRequest) {
     const response = NextResponse.json({ url: authResponse.headers.get('Location') ?? authResponse.url });
     response.headers.set('Set-Cookie', authResponse.headers.get('Set-Cookie') ?? '');
 
-    cookies().set(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS, 'true', {httpOnly: false})
+    cookies().set(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS, 'true', {httpOnly: false});
 
     return response;
   } else {
@@ -51,8 +51,8 @@ export async function POST(request: NextRequest) {
 export async function GET(request: NextRequest) {
   // Call out to the API server's /auth/tokens endpoint to retrieve all tokens for a user
 
-  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration())
-  const userApiClientWithAuthHeader = new UsersAPIApi(createAuthenticatedApiConfiguration())
+  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration());
+  const userApiClientWithAuthHeader = new UsersAPIApi(createAuthenticatedApiConfiguration());
 
   const response = await userApiClientWithAuthHeader.getUserByLoginId("me");
 
@@ -60,10 +60,10 @@ export async function GET(request: NextRequest) {
 
   if (loginId) {
 
-    const tokens = await authApiClientWithAuthHeader.getTokens(Constants.CLIENT_API_VERSION, loginId)
+    const tokens = await authApiClientWithAuthHeader.getTokens(Constants.CLIENT_API_VERSION, loginId);
     
     const serializedTokens = JSON.stringify(tokens.tokens);
-    return (new NextResponse(serializedTokens, {status: 200}))
+    return (new NextResponse(serializedTokens, {status: 200}));
 
   } else {
     return (new NextResponse("No login ID provided", {status : 400}));
@@ -79,10 +79,10 @@ export async function DELETE(request: NextRequest){
     return new NextResponse('Token ID is required', { status: 400 });
   }
 
-  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration())
+  const authApiClientWithAuthHeader = new AuthenticationAPIApi(createAuthenticatedApiConfiguration());
 
-  await authApiClientWithAuthHeader.deleteToken(tokenId)  
+  await authApiClientWithAuthHeader.deleteToken(tokenId);  
 
-  return (new NextResponse(null, {status: 204}))
+  return (new NextResponse(null, {status: 204}));
 
 }

--- a/galasa-ui/src/app/home/route.ts
+++ b/galasa-ui/src/app/home/route.ts
@@ -4,23 +4,23 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { ConfigurationPropertyStoreAPIApi } from "@/generated/galasaapi"
-import { createAuthenticatedApiConfiguration } from "@/utils/api"
+import { ConfigurationPropertyStoreAPIApi } from "@/generated/galasaapi";
+import { createAuthenticatedApiConfiguration } from "@/utils/api";
 import { NextResponse } from "next/server";
 
-const NAMESPACE = "service"
-const PROPERTY_NAME = "welcome.markdown"
+const NAMESPACE = "service";
+const PROPERTY_NAME = "welcome.markdown";
 
 export async function GET() {
 
-    let data;
-    const cpsApiClientWithAuthHeader = new ConfigurationPropertyStoreAPIApi(createAuthenticatedApiConfiguration());
-    const response = await cpsApiClientWithAuthHeader.getCpsProperty(NAMESPACE, PROPERTY_NAME);
+  let data;
+  const cpsApiClientWithAuthHeader = new ConfigurationPropertyStoreAPIApi(createAuthenticatedApiConfiguration());
+  const response = await cpsApiClientWithAuthHeader.getCpsProperty(NAMESPACE, PROPERTY_NAME);
 
-    if (response.length > 0 && response[0]) {
-        data = response[0].data?.value;
-    }
+  if (response.length > 0 && response[0]) {
+    data = response[0].data?.value;
+  }
 
-    return (new NextResponse(data, { status: 200 }))
+  return new NextResponse(data, { status: 200 });
 
 }

--- a/galasa-ui/src/app/myprofile/page.tsx
+++ b/galasa-ui/src/app/myprofile/page.tsx
@@ -3,73 +3,73 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
+'use client';
 
 import { useEffect, useState } from "react";
-import { Loading, ToastNotification } from "@carbon/react"
-import styles from "../../styles/MyProfile.module.css"
+import { Loading, ToastNotification } from "@carbon/react";
+import styles from "../../styles/MyProfile.module.css";
 import PageTile from "@/components/PageTile";
 
 export default function MyProfilePage() {
 
-    const [isLoading, setIsLoading] = useState(false)
-    const [isError, setIsError] = useState(false)
-    const [loginId, setLoginId] = useState("")
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [loginId, setLoginId] = useState("");
 
-    const handleFetchUserData = async () => {
+  const handleFetchUserData = async () => {
 
-        setIsLoading(true)
+    setIsLoading(true);
 
-        try {
-            const response = await fetch('/users', { method: 'GET' })
+    try {
+      const response = await fetch('/users', { method: 'GET' });
 
-            if (response.ok) {
+      if (response.ok) {
 
-                const data = await response.text();
-                setLoginId(data)
+        const data = await response.text();
+        setLoginId(data);
 
-            }
+      }
 
-        } catch (err) {
-            setIsError(true)
-            console.log(err);
-        }
-        finally {
-            setIsLoading(false)
-        }
-
+    } catch (err) {
+      setIsError(true);
+      console.log(err);
+    }
+    finally {
+      setIsLoading(false);
     }
 
-    useEffect(() => {
+  };
 
-        handleFetchUserData()
+  useEffect(() => {
 
-    }, [])
+    handleFetchUserData();
 
-    return (
-        <div id="content" className={styles.content}>
-            <PageTile title={"My Profile"} />
+  }, []);
 
-            {isLoading ?
-                <Loading data-testid="loader" small={false} active={isLoading} />
-                :
-                <div className={styles.userNameContainer}>
-                    <h4>Currently logged in as:</h4>
-                    <h4> &nbsp; {loginId}</h4>
-                </div>
-            }
+  return (
+    <div id="content" className={styles.content}>
+      <PageTile title={"My Profile"} />
 
-            {isError &&
-                <ToastNotification
-                    aria-label="closes notification"
-                    kind="error"
-                    onClose={function noRefCheck() { }}
-                    onCloseButtonClick={function noRefCheck() { setIsError(false)}}
-                    statusIconDescription="notification"
-                    caption="Failed to fetch user profile data."
-                    title="Internal Server Error"
-                />    
-            }
+      {isLoading ?
+        <Loading data-testid="loader" small={false} active={isLoading} />
+        :
+        <div className={styles.userNameContainer}>
+          <h4>Currently logged in as:</h4>
+          <h4> &nbsp; {loginId}</h4>
         </div>
-    );
+      }
+
+      {isError &&
+                <ToastNotification
+                  aria-label="closes notification"
+                  kind="error"
+                  onClose={function noRefCheck() { }}
+                  onCloseButtonClick={function noRefCheck() { setIsError(false);}}
+                  statusIconDescription="notification"
+                  caption="Failed to fetch user profile data."
+                  title="Internal Server Error"
+                />    
+      }
+    </div>
+  );
 };

--- a/galasa-ui/src/app/users/route.ts
+++ b/galasa-ui/src/app/users/route.ts
@@ -14,27 +14,27 @@ export const dynamic = 'force-dynamic';
 
 export async function GET() {
 
-    try {
+  try {
         
-        const userApiClientWithAuthHeader = new UsersAPIApi(createAuthenticatedApiConfiguration())
+    const userApiClientWithAuthHeader = new UsersAPIApi(createAuthenticatedApiConfiguration());
 
-        const response = await userApiClientWithAuthHeader.getUserByLoginId("me")
+    const response = await userApiClientWithAuthHeader.getUserByLoginId("me");
 
-        return (new NextResponse(response[0].loginId, { status: 200 }))
-    } catch (err) {
-        throw new Error("Failed to get login id of user")
-    }
+    return (new NextResponse(response[0].loginId, { status: 200 }));
+  } catch (err) {
+    throw new Error("Failed to get login id of user");
+  }
 
 }
 
 export async function DELETE() {
 
-    // an api route is made because, cookies are server side props and cannot be access directly on components
-    // that use 'use client' keyword.
+  // an api route is made because, cookies are server side props and cannot be access directly on components
+  // that use 'use client' keyword.
 
-    cookies().delete(AuthCookies.ID_TOKEN)
-    cookies().delete(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS)
+  cookies().delete(AuthCookies.ID_TOKEN);
+  cookies().delete(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS);
   
-    return (new NextResponse(null, { status: 204 }))
+  return (new NextResponse(null, { status: 204 }));
   
-  }
+}

--- a/galasa-ui/src/components/HomeContent.tsx
+++ b/galasa-ui/src/components/HomeContent.tsx
@@ -3,74 +3,73 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
-import { Section } from "@carbon/react"
-import styles from "../styles/HomeContent.module.css"
+'use client';
+import { Section } from "@carbon/react";
+import styles from "../styles/HomeContent.module.css";
 import { useEffect, useState } from "react";
-import MarkdownIt from 'markdown-it'
+import MarkdownIt from 'markdown-it';
 
 export default function HomeContent() {
 
-    const [markdownContent, setMarkdownContent] = useState<string>("")
-    const [cpsMarkdownContent, setCpsMarkdownContent] = useState<string>("")
+  const [markdownContent, setMarkdownContent] = useState<string>("");
+  const [cpsMarkdownContent, setCpsMarkdownContent] = useState<string>("");
 
+  useEffect(() => {
     let md = new MarkdownIt({
-        html: false
+      html: false
     });
 
     //fetching CPS properties from API
     //Overrides the default markdown content present in /public/static/markdown/home-contents.md
     const fetchHomeTitleFromCps = async () => {
 
-        try {
-            const response = await fetch("/home", { method: "GET" });
+      try {
+        const response = await fetch("/home", { method: "GET" });
 
-            if (response.ok) {
+        if (response.ok) {
 
-                let markdownFileContent = await response.text();
+          let markdownFileContent = await response.text();
 
-                let result = md.render(markdownFileContent)
+          let result = md.render(markdownFileContent);
 
-                setCpsMarkdownContent(result)
-            }
-        } catch (err) {
-            console.error('Error fetching or processing the markdown file', err);
+          setCpsMarkdownContent(result);
         }
-    }
+      } catch (err) {
+        console.error('Error fetching or processing the markdown file', err);
+      }
+    };
 
     //fetching markdown content from local project files
     //will be used as default if no CPS property is set
     const fetchMarkdown = async () => {
-        try {
-            // Fetch the markdown file from the public/static folder
-            const response = await fetch('/static/markdown/home-contents.md');
-            const text = await response.text();
+      try {
+        // Fetch the markdown file from the public/static folder
+        const response = await fetch('/static/markdown/home-contents.md');
+        const text = await response.text();
 
-            // Convert the markdown to HTML
-            const processedContent = await md.render(text)
-            setMarkdownContent(processedContent.toString());
-        } catch (error) {
-            console.error('Error fetching or processing the markdown file', error);
-        }
+        // Convert the markdown to HTML
+        const processedContent = md.render(text);
+        setMarkdownContent(processedContent.toString());
+      } catch (error) {
+        console.error('Error fetching or processing the markdown file', error);
+      }
     };
+    Promise.all([fetchHomeTitleFromCps(), fetchMarkdown()]);
+  }, []);
 
-    useEffect(() => {
-        Promise.all([fetchHomeTitleFromCps(), fetchMarkdown()])
-    }, [])
-
-    return (
-        <Section level={1}>
-            <div className={styles.homeContentWrapper}>
+  return (
+    <Section level={1}>
+      <div className={styles.homeContentWrapper}>
                 
-                {   
-                    cpsMarkdownContent ? <div dangerouslySetInnerHTML={{ __html: cpsMarkdownContent }} />
-                    :
-                    <div dangerouslySetInnerHTML={{ __html: markdownContent }} />
-                }
+        {   
+          cpsMarkdownContent ? <div dangerouslySetInnerHTML={{ __html: cpsMarkdownContent }} />
+            :
+            <div dangerouslySetInnerHTML={{ __html: markdownContent }} />
+        }
 
-            </div>
+      </div>
 
-        </Section>
-    )
+    </Section>
+  );
 
 }

--- a/galasa-ui/src/components/LeftHeaderMenu.tsx
+++ b/galasa-ui/src/components/LeftHeaderMenu.tsx
@@ -3,36 +3,36 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
+'use client';
 
 import { OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { Menu } from "@carbon/icons-react"
-import { useRouter } from "next/navigation"
+import { Menu } from "@carbon/icons-react";
+import { useRouter } from "next/navigation";
 
 export default function LeftHeaderMenu() {
 
-    const router = useRouter()
+  const router = useRouter();
 
-    const handleRedirectToHome = () => {
-        router.push("/")
-    }
+  const handleRedirectToHome = () => {
+    router.push("/");
+  };
 
-    return (
+  return (
 
-        <OverflowMenu
-            data-floating-menu-container
-            selectorPrimaryFocus={'.optionOne'}
-            renderIcon={Menu}
-            data-testid='left-menu-btn'
-            size='lg'
-            flipped={false}
-        >
-            <OverflowMenuItem
-                itemText="Home"
-                data-testid='home-btn'
-                onClick={handleRedirectToHome}
-            />
-        </OverflowMenu>
+    <OverflowMenu
+      data-floating-menu-container
+      selectorPrimaryFocus={'.optionOne'}
+      renderIcon={Menu}
+      data-testid='left-menu-btn'
+      size='lg'
+      flipped={false}
+    >
+      <OverflowMenuItem
+        itemText="Home"
+        data-testid='home-btn'
+        onClick={handleRedirectToHome}
+      />
+    </OverflowMenu>
 
-    )
+  );
 }

--- a/galasa-ui/src/components/MySettingsPage.tsx
+++ b/galasa-ui/src/components/MySettingsPage.tsx
@@ -3,13 +3,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
+'use client';
 
 import { useEffect, useState } from "react";
-import { Loading, Button } from "@carbon/react"
-import styles from "@/styles/MySettings.module.css"
+import { Loading, Button } from "@carbon/react";
+import styles from "@/styles/MySettings.module.css";
 import TokenCard from "@/components/TokenCard";
-import ErrorPage from "@/app/error/page"
+import ErrorPage from "@/app/error/page";
 import TokenRequestModal from "@/components/TokenRequestModal";
 import TokenDeleteModal from "@/components/TokenDeleteModal";
 import Token from "@/utils/interfaces/Token";
@@ -17,130 +17,130 @@ import PageTile from "./PageTile";
 
 export default function MySettingsPage() {
 
-    const [isLoading, setIsLoading] = useState(false)
-    const [isError, setIsError] = useState(false)
-    const [selectedTokens, setSelectedTokens] = useState<Set<string>>(new Set());
-    const [tokens, setTokens] = useState<Set<Token>>(new Set())
-    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+  const [selectedTokens, setSelectedTokens] = useState<Set<string>>(new Set());
+  const [tokens, setTokens] = useState<Set<Token>>(new Set());
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
 
 
-    const selectTokenForDeletion = (tokenId: string) => {
+  const selectTokenForDeletion = (tokenId: string) => {
 
-        if (selectedTokens.has(tokenId)) {
+    if (selectedTokens.has(tokenId)) {
 
-            setSelectedTokens((prevSelectedTokens) => {
-                const newSet = new Set(prevSelectedTokens);
-                newSet.delete(tokenId);
-                return newSet;
-            });
-        }
-        else {
-            setSelectedTokens((prevSelectedTokens) => {
-                const newSet = new Set(prevSelectedTokens);
-                newSet.add(tokenId);
-                return newSet;
-            });
-
-        }
+      setSelectedTokens((prevSelectedTokens) => {
+        const newSet = new Set(prevSelectedTokens);
+        newSet.delete(tokenId);
+        return newSet;
+      });
     }
-
-    const fetchAccessTokens = async () => {
-
-        setIsLoading(true)
-
-        try {
-            const response = await fetch('/auth/tokens', { method: 'GET' })
-
-            if (response.ok) {
-
-                const data = await response.json();
-
-                setTokens(data)
-
-            }
-
-        } catch (err) {
-            setIsError(true)
-        }
-        finally {
-            setIsLoading(false)
-        }
+    else {
+      setSelectedTokens((prevSelectedTokens) => {
+        const newSet = new Set(prevSelectedTokens);
+        newSet.add(tokenId);
+        return newSet;
+      });
 
     }
+  };
 
-    const updateDeleteModalState = () => {
-        setIsDeleteModalOpen(false)
+  const fetchAccessTokens = async () => {
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('/auth/tokens', { method: 'GET' });
+
+      if (response.ok) {
+
+        const data = await response.json();
+
+        setTokens(data);
+
+      }
+
+    } catch (err) {
+      setIsError(true);
+    }
+    finally {
+      setIsLoading(false);
     }
 
-    const deleteTokenFromSet = (token: Token) => {
-        setTokens((prevTokens) => {
-            const newTokens = new Set(prevTokens);
-            newTokens.delete(token);
-            return newTokens;
-        });
+  };
 
-        setSelectedTokens((prevSelectedTokens) => {
-            const newSelectedTokens = new Set(prevSelectedTokens);
-            newSelectedTokens.delete(token.tokenId);
-            return newSelectedTokens;
-        });
+  const updateDeleteModalState = () => {
+    setIsDeleteModalOpen(false);
+  };
 
-        setIsDeleteModalOpen(false)
-    }
+  const deleteTokenFromSet = (token: Token) => {
+    setTokens((prevTokens) => {
+      const newTokens = new Set(prevTokens);
+      newTokens.delete(token);
+      return newTokens;
+    });
 
-    useEffect(() => {
+    setSelectedTokens((prevSelectedTokens) => {
+      const newSelectedTokens = new Set(prevSelectedTokens);
+      newSelectedTokens.delete(token.tokenId);
+      return newSelectedTokens;
+    });
 
-        fetchAccessTokens()
+    setIsDeleteModalOpen(false);
+  };
 
-    }, [])
+  useEffect(() => {
 
-    if (isLoading) {
-        return <Loading />
-    }
+    fetchAccessTokens();
 
-    if (isError) {
-        return (
-            <ErrorPage />
-        )
-    }
+  }, []);
 
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (isError) {
     return (
-        <div id="content" className={styles.container}>
-
-            <PageTile title={"My Settings"} />
-
-            <div className={styles.tokenContainer}>
-                <h4 className={styles.title}>Access Tokens</h4>
-
-                <div className={styles.pageHeaderContainer}>
-                    <div>
-                        <h5 className={styles.heading}>An access token is a unique secret key held by a client program so it has permission to use the Galasa service</h5>
-                        <h5 className={styles.heading}>A token has the same access rights as the user who allocated it.</h5>
-                    </div>
-
-                    <div className={styles.btnContainer}>
-                        <TokenRequestModal isDisabled={selectedTokens.size > 0 ? true : false} />
-
-                        <Button onClick={() => setIsDeleteModalOpen(true)} className={styles.deleteBtn} disabled={selectedTokens.size === 0} kind="danger">
-                            Delete {selectedTokens.size} selected access tokens
-                        </Button>
-                    </div>
-                </div>
-
-                <div title="Access Tokens" className={styles.tokensList}>
-                    {
-                        Array.from(tokens).map((token) => (
-                            <TokenCard key={token.tokenId} token={token} selectTokenForDeletion={selectTokenForDeletion} />
-                        ))
-                    }
-                </div>
-
-                {
-                    isDeleteModalOpen && <TokenDeleteModal tokens={tokens} selectedTokens={selectedTokens} deleteTokenFromSet={deleteTokenFromSet} updateDeleteModalState={updateDeleteModalState} />
-                }
-            </div>
-
-        </div>
+      <ErrorPage />
     );
+  }
+
+  return (
+    <div id="content" className={styles.container}>
+
+      <PageTile title={"My Settings"} />
+
+      <div className={styles.tokenContainer}>
+        <h4 className={styles.title}>Access Tokens</h4>
+
+        <div className={styles.pageHeaderContainer}>
+          <div>
+            <h5 className={styles.heading}>An access token is a unique secret key held by a client program so it has permission to use the Galasa service</h5>
+            <h5 className={styles.heading}>A token has the same access rights as the user who allocated it.</h5>
+          </div>
+
+          <div className={styles.btnContainer}>
+            <TokenRequestModal isDisabled={selectedTokens.size > 0 ? true : false} />
+
+            <Button onClick={() => setIsDeleteModalOpen(true)} className={styles.deleteBtn} disabled={selectedTokens.size === 0} kind="danger">
+                            Delete {selectedTokens.size} selected access tokens
+            </Button>
+          </div>
+        </div>
+
+        <div title="Access Tokens" className={styles.tokensList}>
+          {
+            Array.from(tokens).map((token) => (
+              <TokenCard key={token.tokenId} token={token} selectTokenForDeletion={selectTokenForDeletion} />
+            ))
+          }
+        </div>
+
+        {
+          isDeleteModalOpen && <TokenDeleteModal tokens={tokens} selectedTokens={selectedTokens} deleteTokenFromSet={deleteTokenFromSet} updateDeleteModalState={updateDeleteModalState} />
+        }
+      </div>
+
+    </div>
+  );
 };

--- a/galasa-ui/src/components/PageHeaderMenu.tsx
+++ b/galasa-ui/src/components/PageHeaderMenu.tsx
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
+'use client';
 
-import React from 'react'
+import React from 'react';
 import { HeaderGlobalBar, OverflowMenu, OverflowMenuItem } from '@carbon/react';
-import { User } from "@carbon/icons-react"
+import { User } from "@carbon/icons-react";
 import { useRouter } from 'next/navigation';
 
 function PageHeaderMenu() {
 
-  const router = useRouter()
+  const router = useRouter();
 
   const handleDeleteCookieApiOperation = async () => {
 
@@ -21,18 +21,18 @@ function PageHeaderMenu() {
     if (response.status === 204) {
 
       //auto redirect to render dex login page
-      router.refresh()
+      router.refresh();
 
     }
-  }
+  };
 
   const handleRedirectToMyProfilePage = () => {
-    router.push("/myprofile")
-  }
+    router.push("/myprofile");
+  };
 
   const handleRedirectToMySettingsPage = () => {
-    router.push("/mysettings")
-  }
+    router.push("/mysettings");
+  };
 
   return (
     <HeaderGlobalBar data-testid="header-menu">
@@ -64,7 +64,7 @@ function PageHeaderMenu() {
       </OverflowMenu>
 
     </HeaderGlobalBar>
-  )
+  );
 }
 
-export default PageHeaderMenu
+export default PageHeaderMenu;

--- a/galasa-ui/src/components/PageTile.tsx
+++ b/galasa-ui/src/components/PageTile.tsx
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-'use client'
+'use client';
 
 import { Tile } from '@carbon/react';
-import "../styles/global.scss"
+import "../styles/global.scss";
 
 export default function PageTile({ title }: { title: String }) {
 
-    return (
-        <Tile id="tile">
-            {title}
-        </Tile>
-    )
+  return (
+    <Tile id="tile">
+      {title}
+    </Tile>
+  );
 
 }

--- a/galasa-ui/src/components/Table.tsx
+++ b/galasa-ui/src/components/Table.tsx
@@ -11,17 +11,17 @@ import dynamic from 'next/dynamic';
 
 
 export function rowData (row: {id: string; tokenName: string; scope: string; expires: string;}){
-    return (
-        <TableRow key={row.id}>
-            <TableCell>{row.tokenName}</TableCell>
-            <TableCell>{row.scope}</TableCell>
-            <TableCell>{row.expires}</TableCell>
-        </TableRow>
-    )
+  return (
+    <TableRow key={row.id}>
+      <TableCell>{row.tokenName}</TableCell>
+      <TableCell>{row.scope}</TableCell>
+      <TableCell>{row.expires}</TableCell>
+    </TableRow>
+  );
 }
 
 export function headerData(header: {key: string;header: string;}){
-    return(<TableHeader key={header.key}>{header.header}</TableHeader>)
+  return(<TableHeader key={header.key}>{header.header}</TableHeader>);
 }
 
 export function CreateTokenTable({headers, rows}:
@@ -29,19 +29,19 @@ export function CreateTokenTable({headers, rows}:
         headers: {key: string;header: string;}[],
         rows: {id: string; tokenName: string; scope: string; expires: string;}[]
     }) {
-    const header = headers.map(header => headerData(header));
-    const row = rows.map(row => rowData(row));
+  const header = headers.map(header => headerData(header));
+  const row = rows.map(row => rowData(row));
   return (
     <Table size="lg" useZebraStyles={false}>
-    <TableHead>
-      <TableRow key='header'>
-        {header}
-      </TableRow>
-    </TableHead>
-    <TableBody>
+      <TableHead>
+        <TableRow key='header'>
+          {header}
+        </TableRow>
+      </TableHead>
+      <TableBody>
         {row}
-    </TableBody>
-  </Table>
+      </TableBody>
+    </Table>
   );
 };
 

--- a/galasa-ui/src/components/TokenCard.tsx
+++ b/galasa-ui/src/components/TokenCard.tsx
@@ -3,39 +3,39 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-'use client'
+'use client';
 
 import { useState } from "react";
-import styles from "../styles/TokenCard.module.css"
+import styles from "../styles/TokenCard.module.css";
 import { Password } from '@carbon/icons-react';
 import { SelectableTile } from '@carbon/react';
 import Token from "@/utils/interfaces/Token";
 
 function TokenCard({token, selectTokenForDeletion} : {token : Token, selectTokenForDeletion: Function}){
 
-    //The token creation time receieved from the API is: e.g 2024-09-25T10:02:55.732580Z
-    // Splitting at "T" will give us the date part of the creationTime ---> split = [2024-09-25 , 10:02:55.732580Z]
-    // split[0] ---> 2024-09-25
-    const trimmedTime = token.creationTime.split("T")
+  //The token creation time receieved from the API is: e.g 2024-09-25T10:02:55.732580Z
+  // Splitting at "T" will give us the date part of the creationTime ---> split = [2024-09-25 , 10:02:55.732580Z]
+  // split[0] ---> 2024-09-25
+  const trimmedTime = token.creationTime.split("T");
 
-    return(
+  return(
 
-        <SelectableTile onClick={() => selectTokenForDeletion(token.tokenId)} value={true} key={token.tokenId} className={styles.cardContainer}>
+    <SelectableTile onClick={() => selectTokenForDeletion(token.tokenId)} value={true} key={token.tokenId} className={styles.cardContainer}>
 
-            <h5>{token.description}</h5>
-            <div className={styles.infoContainer}>
+      <h5>{token.description}</h5>
+      <div className={styles.infoContainer}>
 
-                <h6>Created at: {trimmedTime[0]}</h6>
-                <h6>Owner: {token.owner.loginId}</h6>
+        <h6>Created at: {trimmedTime[0]}</h6>
+        <h6>Owner: {token.owner.loginId}</h6>
                 
-            </div>
+      </div>
 
-            <Password className={styles.icon} size={40}/>
+      <Password className={styles.icon} size={40}/>
 
-        </SelectableTile>
+    </SelectableTile>
         
-    )
+  );
 
 }
 
-export default TokenCard
+export default TokenCard;

--- a/galasa-ui/src/components/TokenDeleteModal.tsx
+++ b/galasa-ui/src/components/TokenDeleteModal.tsx
@@ -8,112 +8,112 @@
 import { useRef, useState } from 'react';
 import { TextInput } from '@carbon/react';
 import { InlineNotification } from '@carbon/react';
-import { Loading,Modal} from "@carbon/react"
+import { Loading,Modal} from "@carbon/react";
 import Token from '@/utils/interfaces/Token';
 import TokenRequestModalProps from '@/utils/interfaces/TokenRequestModalProps';
 
 export default function TokenRequestModal({ tokens, selectedTokens, deleteTokenFromSet, updateDeleteModalState }: TokenRequestModalProps) {
 
-    const [open, setOpen] = useState(true);
-    const [error, setError] = useState('');
-    const [isLoading, setIsLoading] = useState(false)
+  const [open, setOpen] = useState(true);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
-    const deleteTokensById = async () => {
+  const deleteTokensById = async () => {
 
-        try {
+    try {
 
-            setIsLoading(true)
-            //Convert set to array so we can iterate for it
-            const tokensArray: Token[] = Array.from(tokens);
+      setIsLoading(true);
+      //Convert set to array so we can iterate for it
+      const tokensArray: Token[] = Array.from(tokens);
 
-            for (const token of tokensArray) {  //using loop to handle multiple token deletion at once
-                if (selectedTokens.has(token.tokenId)) {
+      for (const token of tokensArray) {  //using loop to handle multiple token deletion at once
+        if (selectedTokens.has(token.tokenId)) {
 
-                    const response = await fetch(`/auth/tokens`, {
-                        method: 'DELETE',
-                        headers: {
-                            'Content-Type': 'application/json',
-                        },
-                        body: JSON.stringify({ tokenId: token.tokenId }),
-                    });
+          const response = await fetch(`/auth/tokens`, {
+            method: 'DELETE',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ tokenId: token.tokenId }),
+          });
 
-                    if (response.status === 204) {
+          if (response.status === 204) {
 
-                        //Update the tokens after deletion
-                        deleteTokenFromSet(token)
-                        setOpen(false)
+            //Update the tokens after deletion
+            deleteTokenFromSet(token);
+            setOpen(false);
 
-                    }
-                }
-            }
-
-        } catch (err) {
-            let errorMessage = '';
-
-            if (err instanceof Error) {
-                errorMessage = err.message;
-            } else {
-                errorMessage = String(err);
-            }
-
-            setError(errorMessage);
-            console.error('Failed to delete a personal access token: %s', err);
+          }
         }
-        finally {
-            setIsLoading(false)
-        }
+      }
 
+    } catch (err) {
+      let errorMessage = '';
+
+      if (err instanceof Error) {
+        errorMessage = err.message;
+      } else {
+        errorMessage = String(err);
+      }
+
+      setError(errorMessage);
+      console.error('Failed to delete a personal access token: %s', err);
+    }
+    finally {
+      setIsLoading(false);
     }
 
-    if(isLoading){
-        <Loading  />
-    }
+  };
+
+  if(isLoading){
+    <Loading  />;
+  }
 
 
-    return (
-        <>
-            <Modal
-                modalHeading="Delete Access Tokens"
-                primaryButtonText="Delete"
-                secondaryButtonText="Cancel"
-                danger
-                shouldSubmitOnEnter={true}
-                open={open}
-                onRequestClose={() => {
-                    setOpen(false);
-                    setError('');
-                    updateDeleteModalState()
-                }}
-                onRequestSubmit={async () => {
-                    await deleteTokensById();
-                }}
-            >
-                <h6 className='margin-top-1'>
+  return (
+    <>
+      <Modal
+        modalHeading="Delete Access Tokens"
+        primaryButtonText="Delete"
+        secondaryButtonText="Cancel"
+        danger
+        shouldSubmitOnEnter={true}
+        open={open}
+        onRequestClose={() => {
+          setOpen(false);
+          setError('');
+          updateDeleteModalState();
+        }}
+        onRequestSubmit={async () => {
+          await deleteTokensById();
+        }}
+      >
+        <h6 className='margin-top-1'>
                     Number of access tokens to delete: {selectedTokens.size}
-                </h6>
+        </h6>
 
-                <div className='margin-top-2'>
-                    <InlineNotification
-                        title="Client programs using these access tokens will no longer have access to this Galasa Service."
-                        subtitle="This operation is irreversible, though new access tokens can be created to replace the ones being deleted."
-                        kind="warning"
-                        lowContrast
-                        hideCloseButton
-                    />
-                </div>
-                <br />
+        <div className='margin-top-2'>
+          <InlineNotification
+            title="Client programs using these access tokens will no longer have access to this Galasa Service."
+            subtitle="This operation is irreversible, though new access tokens can be created to replace the ones being deleted."
+            kind="warning"
+            lowContrast
+            hideCloseButton
+          />
+        </div>
+        <br />
 
-                {error && (
-                    <InlineNotification
-                        className="margin-top-1"
-                        title="Error deleting access token"
-                        subtitle={error}
-                        kind="error"
-                        onCloseButtonClick={() => setError('')}
-                        lowContrast
-                    />
-                )}
-            </Modal>
-        </>
-    );
+        {error && (
+          <InlineNotification
+            className="margin-top-1"
+            title="Error deleting access token"
+            subtitle={error}
+            kind="error"
+            onCloseButtonClick={() => setError('')}
+            lowContrast
+          />
+        )}
+      </Modal>
+    </>
+  );
 };

--- a/galasa-ui/src/components/TokenRequestModal.tsx
+++ b/galasa-ui/src/components/TokenRequestModal.tsx
@@ -28,8 +28,8 @@ export default function TokenRequestModal({isDisabled} : {isDisabled : boolean})
       const response = await fetch('/auth/tokens', {
         method: 'POST',
         body: JSON.stringify({
-            tokenDescription: tokenNameInputRef.current?.value
-          }),
+          tokenDescription: tokenNameInputRef.current?.value
+        }),
       });
 
       if (!response.ok) {
@@ -55,7 +55,7 @@ export default function TokenRequestModal({isDisabled} : {isDisabled : boolean})
   return (
     <>
       <Button iconDescription={"Create new access token"} role="token-request-btn" disabled={isDisabled} hasIconOnly onClick={() => setOpen(true)}>
-          <Add/>
+        <Add/>
       </Button>
       <Modal
         modalHeading="Personal access token request"

--- a/galasa-ui/src/middleware.ts
+++ b/galasa-ui/src/middleware.ts
@@ -18,10 +18,10 @@ export async function middleware(request: NextRequest) {
     if (request.url.includes('/callback')) {
       let responseUrl = request.url.substring(0, request.url.lastIndexOf('/callback'));
 
-      const shouldReturnToMySettingsPage = cookies().get(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS)
+      const shouldReturnToMySettingsPage = cookies().get(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS);
     
       if(shouldReturnToMySettingsPage?.value === 'true'){
-        responseUrl = responseUrl + "/mysettings"
+        responseUrl = responseUrl + "/mysettings";
       }
       
       response = await handleCallback(request, NextResponse.redirect(responseUrl, { status: 302 }));

--- a/galasa-ui/src/tests/components/Sidebar.test.tsx
+++ b/galasa-ui/src/tests/components/Sidebar.test.tsx
@@ -11,12 +11,12 @@ beforeEach (()=>{
 });
 
 test('renders Galasa Modal Token Request', () => {
-    const tokenManagementEelement = screen.getByText(/Token Management/i);
-    const loginElement = screen.getByText(/You are logged in as:/i);
-    const previousLoginElement = screen.getByText(/Previous login/i);
-    const accessRolesElement = screen.getByText(/Your access roles:/i);
-    expect(tokenManagementEelement).toBeInTheDocument();
-    expect(loginElement).toBeInTheDocument();
-    expect(previousLoginElement).toBeInTheDocument();
-    expect(accessRolesElement).toBeInTheDocument();
-  });
+  const tokenManagementEelement = screen.getByText(/Token Management/i);
+  const loginElement = screen.getByText(/You are logged in as:/i);
+  const previousLoginElement = screen.getByText(/Previous login/i);
+  const accessRolesElement = screen.getByText(/Your access roles:/i);
+  expect(tokenManagementEelement).toBeInTheDocument();
+  expect(loginElement).toBeInTheDocument();
+  expect(previousLoginElement).toBeInTheDocument();
+  expect(accessRolesElement).toBeInTheDocument();
+});

--- a/galasa-ui/src/tests/components/Tables.test.tsx
+++ b/galasa-ui/src/tests/components/Tables.test.tsx
@@ -31,37 +31,37 @@ test('renders Galasa Token Table', () => {
 
 
 test('creates Galasa Token Table header', () => {
-    const header = {key: 'tokenName',header: 'Token'};
-    const headerToken = headerData(header);
-    const expectedToken = <TableHeader key='tokenName'>Token</TableHeader>
-    expect(headerToken).toEqual(expectedToken);
-  });
+  const header = {key: 'tokenName',header: 'Token'};
+  const headerToken = headerData(header);
+  const expectedToken = <TableHeader key='tokenName'>Token</TableHeader>;
+  expect(headerToken).toEqual(expectedToken);
+});
 
-  test('creates Galasa Token Table headers', () => {
-    const headers = [{key: 'tokenName',header: 'Token'},{key: 'scope',header: 'scope'}];
-    const headerToken = headers.map(header => headerData(header))
-    const expectedToken = <TableHeader key='tokenName'>Token</TableHeader>;
-    const expectedscope = <TableHeader key='scope'>scope</TableHeader>;
-    expect(headerToken[0]).toEqual(expectedToken);
-    expect(headerToken[1]).toEqual(expectedscope);
-  });
+test('creates Galasa Token Table headers', () => {
+  const headers = [{key: 'tokenName',header: 'Token'},{key: 'scope',header: 'scope'}];
+  const headerToken = headers.map(header => headerData(header));
+  const expectedToken = <TableHeader key='tokenName'>Token</TableHeader>;
+  const expectedscope = <TableHeader key='scope'>scope</TableHeader>;
+  expect(headerToken[0]).toEqual(expectedToken);
+  expect(headerToken[1]).toEqual(expectedscope);
+});
 
 test('creates Galasa Token Table row', () => {
-    const row = {id: '4321', tokenName: 'Token1Example', scope: 'ALL', expires: '2023-10-22'};
-    const rowReturned = rowData(row);
-    const expectedRow = <TableRow key='4321'>
-        <TableCell>Token1Example</TableCell>
-        <TableCell>ALL</TableCell>
-        <TableCell>2023-10-22</TableCell>
-    </TableRow>
-    expect(rowReturned).toEqual(expectedRow);
+  const row = {id: '4321', tokenName: 'Token1Example', scope: 'ALL', expires: '2023-10-22'};
+  const rowReturned = rowData(row);
+  const expectedRow = <TableRow key='4321'>
+    <TableCell>Token1Example</TableCell>
+    <TableCell>ALL</TableCell>
+    <TableCell>2023-10-22</TableCell>
+  </TableRow>;
+  expect(rowReturned).toEqual(expectedRow);
 });
 
 test('creates Galasa Token Table row', () => {
   const rows = [{id: '4321', tokenName: 'Token1Example', scope: 'ALL', expires: '2023-10-22'},{id: '5678', tokenName: 'Token2Example', scope: 'Local', expires: '2023-09-10'}];
   const rowReturned = rows.map(header => rowData(header));
-  const expectedToken1 = <TableRow key='4321'><TableCell>Token1Example</TableCell><TableCell>ALL</TableCell><TableCell>2023-10-22</TableCell></TableRow>
-  const expectedToken2 = <TableRow key='5678'><TableCell>Token2Example</TableCell><TableCell>Local</TableCell><TableCell>2023-09-10</TableCell></TableRow>
+  const expectedToken1 = <TableRow key='4321'><TableCell>Token1Example</TableCell><TableCell>ALL</TableCell><TableCell>2023-10-22</TableCell></TableRow>;
+  const expectedToken2 = <TableRow key='5678'><TableCell>Token2Example</TableCell><TableCell>Local</TableCell><TableCell>2023-09-10</TableCell></TableRow>;
   expect(rowReturned[0]).toEqual(expectedToken1);
   expect(rowReturned[1]).toEqual(expectedToken2);
 });

--- a/galasa-ui/src/tests/header.test.tsx
+++ b/galasa-ui/src/tests/header.test.tsx
@@ -9,34 +9,34 @@ import { render, screen } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
 
 const mockRouter = {
-    refresh: jest.fn(() => useRouter().refresh),
+  refresh: jest.fn(() => useRouter().refresh),
 };
 
 jest.mock('next/navigation', () => ({
 
-    useRouter: jest.fn(() => mockRouter),
+  useRouter: jest.fn(() => mockRouter),
 
-}))
+}));
 
 
 test('renders Galasa Service header title when env GALASA_SERVICE_NAME is null or blank string', () => {
 
-    render(<PageHeader galasaServiceName="Galasa Service" />);
+  render(<PageHeader galasaServiceName="Galasa Service" />);
 
-    const titleElement = screen.getByText("Galasa Service");
-    expect(titleElement.textContent).toBe("Galasa Service")
-    expect(titleElement).toBeInTheDocument();
+  const titleElement = screen.getByText("Galasa Service");
+  expect(titleElement.textContent).toBe("Galasa Service");
+  expect(titleElement).toBeInTheDocument();
 
 });
 
 
 test('renders custom header when title when env GALASA_SERVICE_NAME is present', () => {
 
-    render(<PageHeader galasaServiceName='Managers' />);
+  render(<PageHeader galasaServiceName='Managers' />);
 
-    const titleElement = screen.getByText("Managers");
-    expect(titleElement.textContent).not.toBe("Galasa Service")
-    expect(titleElement.textContent).toBe("Managers")
-    expect(titleElement).toBeInTheDocument();
+  const titleElement = screen.getByText("Managers");
+  expect(titleElement.textContent).not.toBe("Galasa Service");
+  expect(titleElement.textContent).toBe("Managers");
+  expect(titleElement).toBeInTheDocument();
 
 });

--- a/galasa-ui/src/tests/homecontent.test.tsx
+++ b/galasa-ui/src/tests/homecontent.test.tsx
@@ -8,55 +8,55 @@ import React from 'react';
 import HomeContent from '@/components/HomeContent';
 
 beforeEach(() => {
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            ok: true,
-            status: 200,
-            statusText: "OK",
-            headers: new Headers(), // Mock Headers
-            redirected: false,
-            type: "basic",
-            url: "",
-            text: jest.fn().mockResolvedValue('# Mocked Markdown Content This is a test'),
-            json: jest.fn(), // Optional mock if needed for other tests
-        } as unknown as Response)
-    );
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers(), // Mock Headers
+      redirected: false,
+      type: "basic",
+      url: "",
+      text: jest.fn().mockResolvedValue('# Mocked Markdown Content This is a test'),
+      json: jest.fn(), // Optional mock if needed for other tests
+    } as unknown as Response)
+  );
 });
 
 afterEach(() => {
-    jest.resetAllMocks();
+  jest.resetAllMocks();
 });
 
 test('renders markdown content', async () => {
-    render(<HomeContent />);
-    const content = await screen.findByText('Mocked Markdown Content This is a test');
-    expect(content).toBeInTheDocument();
+  render(<HomeContent />);
+  const content = await screen.findByText('Mocked Markdown Content This is a test');
+  expect(content).toBeInTheDocument();
 });
 
 test("render home content title", async () => {
 
-    render(<HomeContent />)
+  render(<HomeContent />);
 
-    await act(async () => {
-        // Simulate the useEffect hook
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    });
+  await act(async () => {
+    // Simulate the useEffect hook
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
 
-    const title = screen.getByText("Mocked Markdown Content This is a test")
+  const title = screen.getByText("Mocked Markdown Content This is a test");
 
-    expect(title).toBeInTheDocument()
-})
+  expect(title).toBeInTheDocument();
+});
 
 test("render home content sub-title", async () => {
 
-    render(<HomeContent />)
+  render(<HomeContent />);
 
-    await act(async () => {
-        // Simulate the useEffect the useEffect hook
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    });
+  await act(async () => {
+    // Simulate the useEffect the useEffect hook
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
 
-    const subTitle = screen.getByText("Mocked Markdown Content This is a test")
+  const subTitle = screen.getByText("Mocked Markdown Content This is a test");
 
-    expect(subTitle).toBeInTheDocument()
-})
+  expect(subTitle).toBeInTheDocument();
+});

--- a/galasa-ui/src/tests/index.test.tsx
+++ b/galasa-ui/src/tests/index.test.tsx
@@ -12,7 +12,7 @@ jest.mock('next/headers', () => ({
   cookies: jest.fn(() => ({
     get: jest.fn().mockReturnValue('')
   }))
-}))
+}));
 
 const mockRouter = {
   refresh : jest.fn(() => useRouter().refresh),
@@ -22,7 +22,7 @@ jest.mock('next/navigation', () => ({
 
   useRouter: jest.fn(() => mockRouter),
 
-}))
+}));
 
 test('renders Galasa header', () => {
   render(<PageHeader galasaServiceName='Galasa Service'/>);

--- a/galasa-ui/src/tests/layout.test.tsx
+++ b/galasa-ui/src/tests/layout.test.tsx
@@ -15,8 +15,8 @@ describe('Layout', () => {
 });
 
 afterEach(() => {
-  delete process.env.GALASA_SERVICE_NAME
-})
+  delete process.env.GALASA_SERVICE_NAME;
+});
 
 const mockRouter = {
   refresh: jest.fn(() => useRouter().refresh),
@@ -26,7 +26,7 @@ jest.mock('next/navigation', () => ({
 
   useRouter: jest.fn(() => mockRouter),
 
-}))
+}));
 
 test('renders Galasa Service title when env GALASA_SERVICE_NAME is null or blank string', () => {
 
@@ -36,8 +36,8 @@ test('renders Galasa Service title when env GALASA_SERVICE_NAME is null or blank
     Hello, world!
   </RootLayout>);
 
-  const titleElement = document.querySelector('title')?.textContent
-  expect(titleElement).toBe("Galasa Service")
+  const titleElement = document.querySelector('title')?.textContent;
+  expect(titleElement).toBe("Galasa Service");
 
 
 });
@@ -47,10 +47,10 @@ test('renders custom title when env GALASA_SERVICE_NAME is not present (not null
   process.env.GALASA_SERVICE_NAME = 'Managers'; //mocking environment variable
   render(<RootLayout>Hello, world!</RootLayout>);
 
-  const titleElement = document.querySelector('title')?.textContent
+  const titleElement = document.querySelector('title')?.textContent;
 
 
-  expect(titleElement).not.toBe("Galasa Service")
-  expect(titleElement).toBe("Managers")
+  expect(titleElement).not.toBe("Galasa Service");
+  expect(titleElement).toBe("Managers");
 
 });

--- a/galasa-ui/src/tests/leftHeaderMenu.test.tsx
+++ b/galasa-ui/src/tests/leftHeaderMenu.test.tsx
@@ -10,57 +10,57 @@ import LeftHeaderMenu from '@/components/LeftHeaderMenu';
 
 
 const mockRouter = {
-    push: jest.fn(() => useRouter().push),
+  push: jest.fn(() => useRouter().push),
 };
 
 jest.mock('next/navigation', () => ({
 
-    useRouter: jest.fn(() => mockRouter),
+  useRouter: jest.fn(() => mockRouter),
 
-}))
+}));
 
 afterEach(() => {
-    jest.clearAllMocks()
-})
+  jest.clearAllMocks();
+});
 
 
 test('checking if the left menu btn exists', () => {
-    render(<LeftHeaderMenu />)
+  render(<LeftHeaderMenu />);
 
-    const menuBtn = screen.getByTestId('left-menu-btn')
-    expect(menuBtn).toBeInTheDocument()
-})
+  const menuBtn = screen.getByTestId('left-menu-btn');
+  expect(menuBtn).toBeInTheDocument();
+});
 
 
 test('renders home btn when menu btn is pressed', async () => {
 
-    render(<LeftHeaderMenu />)
+  render(<LeftHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('left-menu-btn'))
+  fireEvent.click(screen.getByTestId('left-menu-btn'));
 
-    const homeBtn = screen.getByTestId('home-btn')
+  const homeBtn = screen.getByTestId('home-btn');
 
-    expect(homeBtn).toBeInTheDocument();
-})
+  expect(homeBtn).toBeInTheDocument();
+});
 
 test('clicking my profile btn redirects me to home page', async () => {
-    render(<LeftHeaderMenu />)
+  render(<LeftHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('left-menu-btn'))
+  fireEvent.click(screen.getByTestId('left-menu-btn'));
 
-    const homeBtn = screen.getByTestId('home-btn')
+  const homeBtn = screen.getByTestId('home-btn');
 
-    expect(homeBtn).toBeInTheDocument();
+  expect(homeBtn).toBeInTheDocument();
 
-    fireEvent.click(homeBtn)
+  fireEvent.click(homeBtn);
 
-    await waitFor(() => {
+  await waitFor(() => {
 
-        expect(mockRouter.push).toHaveBeenCalled()
-        expect(mockRouter.push).toHaveBeenCalledWith("/")
-        expect(mockRouter.push).toHaveBeenCalledTimes(1)
+    expect(mockRouter.push).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith("/");
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
 
-    })
+  });
 
-})
+});
 

--- a/galasa-ui/src/tests/myprofile.test.tsx
+++ b/galasa-ui/src/tests/myprofile.test.tsx
@@ -8,13 +8,61 @@ import { render, screen, waitFor } from '@testing-library/react';
 import MyProfilePage from "../app/myprofile/page";
 
 global.fetch = jest.fn(() =>
-    Promise.resolve({
+  Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve('admin'),
+    headers: new Headers(),
+    redirected: false,
+    status: 200,
+    statusText: 'OK',
+    type: 'default',
+    url: '',
+    clone: jest.fn(),
+    body: null,
+    bodyUsed: false,
+    arrayBuffer: jest.fn(),
+    blob: jest.fn(),
+    formData: jest.fn(),
+    json: jest.fn(),
+  })
+);
+
+
+describe('MyProfilePage', () => {
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders loading spinner initially', () => {
+    render(<MyProfilePage />);
+
+    // Assert that the loading spinner is shown initially
+    const loader = screen.getByTestId('loader');
+    expect(loader).toBeInTheDocument();
+  });
+
+  test('fetches and displays user data', async () => {
+    render(<MyProfilePage />);
+
+    // Wait for the data to be fetched and the loading spinner to disappear
+    await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());
+
+    // Assert that the user's login ID is displayed correctly
+    expect(screen.getByText(/Currently logged in as:/)).toBeInTheDocument();
+    // expect(screen.getByText(/admin/)).toBeInTheDocument();
+  });
+
+  test('handles fetch failure gracefully', async () => {
+    // Mock a failed fetch request
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
         ok: true,
-        text: () => Promise.resolve('admin'),
+        text: () => Promise.resolve(''),
         headers: new Headers(),
         redirected: false,
-        status: 200,
-        statusText: 'OK',
+        status: 500,
+        statusText: 'INTERNAL SERVER ERROR',
         type: 'default',
         url: '',
         clone: jest.fn(),
@@ -24,64 +72,16 @@ global.fetch = jest.fn(() =>
         blob: jest.fn(),
         formData: jest.fn(),
         json: jest.fn(),
-    })
-);
+      })
+    );
 
+    render(<MyProfilePage />);
 
-describe('MyProfilePage', () => {
+    // Wait for the fetch operation to complete
+    await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());
 
-    afterEach(() => {
-        jest.clearAllMocks()
-    })
+    // Assert that no user data is displayed
+    expect(screen.getByText(/Currently logged in as:/)).toBeInTheDocument();
 
-    test('renders loading spinner initially', () => {
-        render(<MyProfilePage />);
-
-        // Assert that the loading spinner is shown initially
-        const loader = screen.getByTestId('loader');
-        expect(loader).toBeInTheDocument();
-    });
-
-    test('fetches and displays user data', async () => {
-        render(<MyProfilePage />);
-
-        // Wait for the data to be fetched and the loading spinner to disappear
-        await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());
-
-        // Assert that the user's login ID is displayed correctly
-        expect(screen.getByText(/Currently logged in as:/)).toBeInTheDocument();
-        // expect(screen.getByText(/admin/)).toBeInTheDocument();
-    });
-
-    test('handles fetch failure gracefully', async () => {
-        // Mock a failed fetch request
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                ok: true,
-                text: () => Promise.resolve(''),
-                headers: new Headers(),
-                redirected: false,
-                status: 500,
-                statusText: 'INTERNAL SERVER ERROR',
-                type: 'default',
-                url: '',
-                clone: jest.fn(),
-                body: null,
-                bodyUsed: false,
-                arrayBuffer: jest.fn(),
-                blob: jest.fn(),
-                formData: jest.fn(),
-                json: jest.fn(),
-            })
-        );
-
-        render(<MyProfilePage />);
-
-        // Wait for the fetch operation to complete
-        await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());
-
-        // Assert that no user data is displayed
-        expect(screen.getByText(/Currently logged in as:/)).toBeInTheDocument();
-
-    });
+  });
 });

--- a/galasa-ui/src/tests/rightHeaderMenu.test.tsx
+++ b/galasa-ui/src/tests/rightHeaderMenu.test.tsx
@@ -9,136 +9,136 @@ import PageHeaderMenu from '@/components/PageHeaderMenu';
 import PageHeader from '@/components/PageHeader';
 import React from 'react';
 
-const fetchMock = jest.spyOn(global, 'fetch')
+const fetchMock = jest.spyOn(global, 'fetch');
 
 const mockRouter = {
-    push: jest.fn(() => useRouter().push),
-    refresh: jest.fn(() => useRouter().refresh)
+  push: jest.fn(() => useRouter().push),
+  refresh: jest.fn(() => useRouter().refresh)
 };
 
 jest.mock('next/navigation', () => ({
 
-    useRouter: jest.fn(() => mockRouter),
+  useRouter: jest.fn(() => mockRouter),
 
-}))
+}));
 
 afterEach(() => {
-    jest.clearAllMocks()
-})
+  jest.clearAllMocks();
+});
 
 
 test('renders the header containing the header menu', () => {
 
-    render(<PageHeader galasaServiceName='Galasa Service' />)
+  render(<PageHeader galasaServiceName='Galasa Service' />);
 
-    const headerMenu = screen.getByTestId('header-menu')
-    expect(headerMenu).toBeInTheDocument()
+  const headerMenu = screen.getByTestId('header-menu');
+  expect(headerMenu).toBeInTheDocument();
 
-})
+});
 
 test('checking if the menu btn exists', () => {
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    const menuBtn = screen.getByTestId('menu-btn')
-    expect(menuBtn).toBeInTheDocument()
-})
+  const menuBtn = screen.getByTestId('menu-btn');
+  expect(menuBtn).toBeInTheDocument();
+});
 
 test('renders logout btn when menu btn is pressed', async () => {
 
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('menu-btn'))
+  fireEvent.click(screen.getByTestId('menu-btn'));
 
-    const logoutBtn = screen.getByTestId('logout-btn')
+  const logoutBtn = screen.getByTestId('logout-btn');
 
-    expect(logoutBtn).toBeInTheDocument();
-})
+  expect(logoutBtn).toBeInTheDocument();
+});
 
 test('renders my profile btn when menu btn is pressed', async () => {
 
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('menu-btn'))
+  fireEvent.click(screen.getByTestId('menu-btn'));
 
-    const myProfileBtn = screen.getByTestId('my-profile-btn')
+  const myProfileBtn = screen.getByTestId('my-profile-btn');
 
-    expect(myProfileBtn).toBeInTheDocument();
-})
+  expect(myProfileBtn).toBeInTheDocument();
+});
 
 
 test('clicking my profile btn redirects me to My Profle Page', async () => {
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('menu-btn'))
+  fireEvent.click(screen.getByTestId('menu-btn'));
 
-    const myProfileBtn = screen.getByTestId('my-profile-btn')
+  const myProfileBtn = screen.getByTestId('my-profile-btn');
 
-    expect(myProfileBtn).toBeInTheDocument();
+  expect(myProfileBtn).toBeInTheDocument();
 
-    fireEvent.click(myProfileBtn)
+  fireEvent.click(myProfileBtn);
 
-    await waitFor(() => {
+  await waitFor(() => {
 
-        expect(mockRouter.push).toHaveBeenCalled()
-        expect(mockRouter.push).toHaveBeenCalledTimes(1)
+    expect(mockRouter.push).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
 
-    })
+  });
 
-})
+});
 
 test('clicking my settings btn redirects me to My Settings Page', async () => {
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    fireEvent.click(screen.getByTestId('menu-btn'))
+  fireEvent.click(screen.getByTestId('menu-btn'));
 
-    const myProfileBtn = screen.getByTestId('my-settings-btn')
+  const myProfileBtn = screen.getByTestId('my-settings-btn');
 
-    expect(myProfileBtn).toBeInTheDocument();
+  expect(myProfileBtn).toBeInTheDocument();
 
-    fireEvent.click(myProfileBtn)
+  fireEvent.click(myProfileBtn);
 
-    await waitFor(() => {
+  await waitFor(() => {
 
-        expect(mockRouter.push).toHaveBeenCalled()
-        expect(mockRouter.push).toHaveBeenCalledTimes(1)
+    expect(mockRouter.push).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledTimes(1);
 
-    })
+  });
 
-})
+});
 
 test('clicking log out button calls handleDeleteCookieApiOperation, RESPONSE OK', async () => {
 
-    render(<PageHeaderMenu />)
+  render(<PageHeaderMenu />);
 
-    const response = new Response(null, {
-        status: 204,
-        statusText: 'OK',
-        headers: {
-            'Content-type': 'application/json',
-        },
-    });
+  const response = new Response(null, {
+    status: 204,
+    statusText: 'OK',
+    headers: {
+      'Content-type': 'application/json',
+    },
+  });
 
-    fetchMock.mockResolvedValueOnce(response)
+  fetchMock.mockResolvedValueOnce(response);
 
-    fireEvent.click(screen.getByTestId('menu-btn'))  //expanding the menu items
+  fireEvent.click(screen.getByTestId('menu-btn'));  //expanding the menu items
 
-    const logoutBtn = screen.getByTestId('logout-btn')
+  const logoutBtn = screen.getByTestId('logout-btn');
 
-    expect(logoutBtn).toBeInTheDocument();
+  expect(logoutBtn).toBeInTheDocument();
 
-    fireEvent.click(logoutBtn)
+  fireEvent.click(logoutBtn);
 
-    await waitFor(() => {
-
-
-        expect(fetchMock).toBeCalledTimes(1)
-
-        expect(mockRouter.refresh).toHaveBeenCalled()
-        expect(mockRouter.refresh).toHaveBeenCalledTimes(1)
-
-    })
+  await waitFor(() => {
 
 
-})
+    expect(fetchMock).toBeCalledTimes(1);
+
+    expect(mockRouter.refresh).toHaveBeenCalled();
+    expect(mockRouter.refresh).toHaveBeenCalledTimes(1);
+
+  });
+
+
+});
 
 

--- a/galasa-ui/src/tests/routes/authTokens.test.ts
+++ b/galasa-ui/src/tests/routes/authTokens.test.ts
@@ -63,9 +63,9 @@ describe('POST /auth/tokens', () => {
 
     const requestBody = JSON.stringify({
       tokenDescription: "my-token"
-    })
+    });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody });
 
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -90,9 +90,9 @@ describe('POST /auth/tokens', () => {
 
     const requestBody = JSON.stringify({
       tokenDescription: "my-token"
-    })
+    });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody });
 
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -116,9 +116,9 @@ describe('POST /auth/tokens', () => {
 
     const requestBody = JSON.stringify({
       tokenDescription: "my-token"
-    })
+    });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "POST", body: requestBody });
 
     global.fetch = jest.fn(() =>
       Promise.resolve({
@@ -148,7 +148,7 @@ describe('GET /auth/tokens', () => {
       owner: {
         loginId: "admin"
       }
-    }]
+    }];
 
     mockAuthenticationApi.mockReturnValue({
       getTokens: jest.fn(() => Promise.resolve({
@@ -163,14 +163,14 @@ describe('GET /auth/tokens', () => {
       }))
     });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "GET" })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "GET" });
 
-    const response = await AuthTokenRoute.GET(request)
+    const response = await AuthTokenRoute.GET(request);
 
-    const serializedTokens = await response.json()
+    const serializedTokens = await response.json();
 
-    expect(response.status).toEqual(200)
-    expect(serializedTokens).toEqual(mockResponseData)
+    expect(response.status).toEqual(200);
+    expect(serializedTokens).toEqual(mockResponseData);
   });
 
   it('should return 400 if no loginId is provided', async () => {
@@ -210,11 +210,11 @@ describe('DELETE /auth/tokens', () => {
 
     const testBody = JSON.stringify({ tokenId });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "DELETE", body: testBody })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "DELETE", body: testBody });
 
-    const response = await AuthTokenRoute.DELETE(request)
+    const response = await AuthTokenRoute.DELETE(request);
 
-    expect(response.status).toEqual(204)
+    expect(response.status).toEqual(204);
     
   });
 
@@ -230,13 +230,13 @@ describe('DELETE /auth/tokens', () => {
 
     const testBody = JSON.stringify({ tokenId });
 
-    const request = new NextRequest("https://my-server/auth/tokens", { method: "DELETE", body: testBody })
+    const request = new NextRequest("https://my-server/auth/tokens", { method: "DELETE", body: testBody });
 
-    const response = await AuthTokenRoute.DELETE(request)
+    const response = await AuthTokenRoute.DELETE(request);
     const responseText = await response.text();
 
-    expect(response.status).toEqual(400)
-    expect(responseText).toEqual("Token ID is required")
+    expect(response.status).toEqual(400);
+    expect(responseText).toEqual("Token ID is required");
     
   });
 

--- a/galasa-ui/src/tests/routes/home.test.ts
+++ b/galasa-ui/src/tests/routes/home.test.ts
@@ -14,36 +14,36 @@ jest.mock("@/utils/api");
 
 describe("GET function", () => {
 
-    let mockGetCpsProperty: jest.Mock<Promise<{ data: { value: string } }[]>, [string, string]>;
+  let mockGetCpsProperty: jest.Mock<Promise<{ data: { value: string } }[]>, [string, string]>;
 
-    beforeEach(() => {
+  beforeEach(() => {
 
-        jest.clearAllMocks();
+    jest.clearAllMocks();
 
-        mockGetCpsProperty = jest.fn();
+    mockGetCpsProperty = jest.fn();
 
-        (ConfigurationPropertyStoreAPIApi as jest.Mock).mockImplementation(() => {
-            return {
-                getCpsProperty: mockGetCpsProperty,
-            };
-        });
-
-        (createAuthenticatedApiConfiguration as jest.Mock).mockReturnValue({});
+    (ConfigurationPropertyStoreAPIApi as jest.Mock).mockImplementation(() => {
+      return {
+        getCpsProperty: mockGetCpsProperty,
+      };
     });
 
-    it("should return a 200 response with data when the API call is successful", async () => {
+    (createAuthenticatedApiConfiguration as jest.Mock).mockReturnValue({});
+  });
 
-        const mockResponse = [
-            { data: { value: "Mocked welcome markdown content" } }
-        ];
-        mockGetCpsProperty.mockResolvedValue(mockResponse);
+  it("should return a 200 response with data when the API call is successful", async () => {
 
-        const result = await GET();
+    const mockResponse = [
+      { data: { value: "Mocked welcome markdown content" } }
+    ];
+    mockGetCpsProperty.mockResolvedValue(mockResponse);
 
-        expect(mockGetCpsProperty).toHaveBeenCalledWith("service", "welcome.markdown");
-        expect(result).toBeInstanceOf(NextResponse);
-        expect(result.status).toBe(200);
-        const bodyText = await result.text(); // Extract text from the response
-        expect(bodyText).toBe("Mocked welcome markdown content");
-    });
+    const result = await GET();
+
+    expect(mockGetCpsProperty).toHaveBeenCalledWith("service", "welcome.markdown");
+    expect(result).toBeInstanceOf(NextResponse);
+    expect(result.status).toBe(200);
+    const bodyText = await result.text(); // Extract text from the response
+    expect(bodyText).toBe("Mocked welcome markdown content");
+  });
 });

--- a/galasa-ui/src/tests/routes/users.test.ts
+++ b/galasa-ui/src/tests/routes/users.test.ts
@@ -29,57 +29,57 @@ jest.mock('next/headers', () => ({
 }));
 
 describe('GET function', () => {
-    const mockBearerToken = 'mocked_bearer_token';
-    const mockUserResponse = 'mocked_login_id';
-    const mockApiConfiguration = {
-      baseServer: { url: 'http://mock-server-url' }, // Mock the baseServer property
-      httpApi: {}, // Mock the httpApi property (could be more detailed)
-      middleware: [], // Mock the middleware array
-      authMethods: {} // Mock the authMethods object
-    };
+  const mockBearerToken = 'mocked_bearer_token';
+  const mockUserResponse = 'mocked_login_id';
+  const mockApiConfiguration = {
+    baseServer: { url: 'http://mock-server-url' }, // Mock the baseServer property
+    httpApi: {}, // Mock the httpApi property (could be more detailed)
+    middleware: [], // Mock the middleware array
+    authMethods: {} // Mock the authMethods object
+  };
   
-    beforeEach(() => {
-      jest.clearAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
   
-      mockedCreateAuthenticatedApiConfiguration.mockReturnValue(mockApiConfiguration as any);
-      mockedUsersAPIApi.prototype.getUserByLoginId = jest.fn().mockResolvedValue(mockUserResponse);
+    mockedCreateAuthenticatedApiConfiguration.mockReturnValue(mockApiConfiguration as any);
+    mockedUsersAPIApi.prototype.getUserByLoginId = jest.fn().mockResolvedValue(mockUserResponse);
       
-    });
-  
-    it('should return the loginId with a 200 status code when successful', async () => {
-      const result = await GET();
-  
-  
-      expect(mockedCreateAuthenticatedApiConfiguration).toHaveBeenCalled();
-      expect(mockedUsersAPIApi).toHaveBeenCalledWith(mockApiConfiguration);
-      expect(result.status).toBe(200);
-    });
-  
-    it('should throw an error if getUserByLoginId fails', async () => {
-      mockedUsersAPIApi.prototype.getUserByLoginId = jest.fn().mockRejectedValue(new Error('API Error'));
-  
-      await expect(GET()).rejects.toThrow('Failed to get login id of user');
-    });
   });
+  
+  it('should return the loginId with a 200 status code when successful', async () => {
+    const result = await GET();
+  
+  
+    expect(mockedCreateAuthenticatedApiConfiguration).toHaveBeenCalled();
+    expect(mockedUsersAPIApi).toHaveBeenCalledWith(mockApiConfiguration);
+    expect(result.status).toBe(200);
+  });
+  
+  it('should throw an error if getUserByLoginId fails', async () => {
+    mockedUsersAPIApi.prototype.getUserByLoginId = jest.fn().mockRejectedValue(new Error('API Error'));
+  
+    await expect(GET()).rejects.toThrow('Failed to get login id of user');
+  });
+});
 
-  describe('DELETE /auth/tokens', () => {
+describe('DELETE /auth/tokens', () => {
 
-    beforeEach(() => {
+  beforeEach(() => {
   
-      jest.clearAllMocks();
-  
-    });
-  
-    it('Fetches cookies from headers, that are not null, GIVES 204 RESPONSE', async () => {
-  
-      const response = await DELETE()
-  
-      expect(deleteMock).toBeCalledWith(AuthCookies.ID_TOKEN);
-      expect(deleteMock).toBeCalledWith(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS)
-      expect(deleteMock).toBeCalledTimes(2)
-      expect(response.status).toBe(204);
-  
-    })
-  
+    jest.clearAllMocks();
   
   });
+  
+  it('Fetches cookies from headers, that are not null, GIVES 204 RESPONSE', async () => {
+  
+    const response = await DELETE();
+  
+    expect(deleteMock).toBeCalledWith(AuthCookies.ID_TOKEN);
+    expect(deleteMock).toBeCalledWith(AuthCookies.SHOULD_REDIRECT_TO_SETTINGS);
+    expect(deleteMock).toBeCalledTimes(2);
+    expect(response.status).toBe(204);
+  
+  });
+  
+  
+});

--- a/galasa-ui/src/utils/constants.ts
+++ b/galasa-ui/src/utils/constants.ts
@@ -7,4 +7,4 @@
 const CLIENT_API_VERSION = "0.38.0";
 
 
-export {CLIENT_API_VERSION}
+export {CLIENT_API_VERSION};

--- a/galasa-ui/src/utils/interfaces/Token.ts
+++ b/galasa-ui/src/utils/interfaces/Token.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-export default interface Token {
+interface Token {
     tokenId: string;
     description: string;
     creationTime: string;
@@ -12,3 +12,5 @@ export default interface Token {
         loginId: string;
     };
 }
+
+export default Token;

--- a/galasa-ui/src/utils/interfaces/TokenRequestModalProps.ts
+++ b/galasa-ui/src/utils/interfaces/TokenRequestModalProps.ts
@@ -6,9 +6,11 @@
 
 import Token from "./Token";
 
-export default interface TokenRequestModalProps {
+interface TokenRequestModalProps {
     tokens: Set<Token>;
     selectedTokens: Set<string>;
     deleteTokenFromSet: Function;
     updateDeleteModalState: Function;
 }
+
+export default TokenRequestModalProps;

--- a/set-version.sh
+++ b/set-version.sh
@@ -1,0 +1,115 @@
+#! /usr/bin/env bash 
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Sets the version number of this component.
+#
+# Environment variable over-rides:
+# None
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+export ORIGINAL_DIR=$(pwd)
+
+cd "${BASEDIR}/.."
+WORKSPACE_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ;}
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ;}
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ;}
+debug() { printf "${white}%s${reset}\n" "$@" ;}
+info() { printf "${white}➜ %s${reset}\n" "$@" ;}
+success() { printf "${green}✔ %s${reset}\n" "$@" ;}
+error() { printf "${red}✖ %s${reset}\n" "$@" ;}
+warn() { printf "${tan}➜ %s${reset}\n" "$@" ;}
+bold() { printf "${bold}%s${reset}\n" "$@" ;}
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ;}
+
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    h1 "Syntax"
+    cat << EOF
+set-version.sh [OPTIONS]
+Options are:
+-v | --version xxx : Mandatory. Set the version number to something explicitly. 
+    For example '--version 0.38.0'
+EOF
+}
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------                   
+component_version=""
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -v | --version )        shift
+                                export component_version=$1
+                                ;;
+        -h | --help )           usage
+                                exit
+                                ;;
+        * )                     error "Unexpected argument $1"
+                                usage
+                                exit 1
+    esac
+    shift
+done
+
+if [[ -z $component_version ]]; then 
+    error "Missing mandatory '--version' argument."
+    usage
+    exit 1
+fi
+
+temp_dir=$BASEDIR/temp/version_bump
+mkdir -p $temp_dir
+
+function bump_build_gradle_version {
+    source_file="$BASEDIR/build.gradle"
+    temp_file="$temp_dir/webui.build.gradle"
+
+    cat $source_file | sed "s/def galasaFrameworkVersion =.*/def galasaFrameworkVersion = \"$component_version\"/1" > $temp_file
+    cp $temp_file $source_file
+}
+
+function bump_client_api_version {
+    source_file="$BASEDIR/galasa-ui/src/utils/constants.ts"
+    temp_file="$temp_dir/webui.constants.ts"
+
+    cat $source_file | sed "s/CLIENT_API_VERSION =.*/CLIENT_API_VERSION = \"$component_version\";/1" > $temp_file
+    cp $temp_file $source_file
+}
+
+bump_build_gradle_version
+bump_client_api_version


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/1947

## Changes
- Copy the `public` folder into the webui's Docker image so that the default markdown content can be rendered correctly.
- Fix `useEffect` warning
- Add set-version script and bumped the framework version being used to 0.38.0
- Added basic linting rules (2-space indentation, semicolons, no irregular whitespace) to help maintain consistency with the existing codebase when adding new content