### PR TITLE
Preventing create button enabling if input is string with space chars

### DIFF
--- a/galasa-ui/src/components/TokenRequestModal.tsx
+++ b/galasa-ui/src/components/TokenRequestModal.tsx
@@ -19,7 +19,7 @@ export default function TokenRequestModal({isDisabled} : {isDisabled : boolean})
   const tokenNameInputRef = useRef<HTMLInputElement>();
 
   const onChangeInputValidation = () => {
-    const tokenName = tokenNameInputRef.current?.value ?? '';
+    const tokenName = tokenNameInputRef.current?.value.trim() ?? '';
     setSubmitDisabled(!tokenName);
   };
 
@@ -28,7 +28,7 @@ export default function TokenRequestModal({isDisabled} : {isDisabled : boolean})
       const response = await fetch('/auth/tokens', {
         method: 'POST',
         body: JSON.stringify({
-          tokenDescription: tokenNameInputRef.current?.value
+          tokenDescription: tokenNameInputRef.current?.value.trim()
         }),
       });
 


### PR DESCRIPTION
# Why?

- Refer to https://github.com/galasa-dev/projectmanagement/issues/2013

- This change will remove any leading and trailing space characters. However spaces between words will still work
- This will not enable the "Create" button until the user presses a non space character

Signed-off-by: Aashir Siddiqui <aashir_sidiki@hotmail.com>

