### PR TITLE
ash webui loginId fix

### DIFF
--- a/galasa-ui/src/app/users/route.ts
+++ b/galasa-ui/src/app/users/route.ts
@@ -6,6 +6,7 @@
 import { UsersAPIApi } from "@/generated/galasaapi";
 import { createAuthenticatedApiConfiguration } from "@/utils/api";
 import AuthCookies from "@/utils/authCookies";
+import * as Constants from "@/utils/constants";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 
@@ -18,7 +19,7 @@ export async function GET() {
         
     const userApiClientWithAuthHeader = new UsersAPIApi(createAuthenticatedApiConfiguration());
 
-    const response = await userApiClientWithAuthHeader.getUserByLoginId("me");
+    const response = await userApiClientWithAuthHeader.getUserByLoginId(Constants.CLIENT_API_VERSION,"me");
 
     return (new NextResponse(response[0].loginId, { status: 200 }));
   } catch (err) {

--- a/galasa-ui/src/tests/routes/users.test.ts
+++ b/galasa-ui/src/tests/routes/users.test.ts
@@ -7,6 +7,7 @@
 import { UsersAPIApi } from '@/generated/galasaapi';
 import { DELETE, GET } from '../../app/users/route';
 import { createAuthenticatedApiConfiguration } from '../../utils/api';
+import * as Constants from "@/utils/constants";
 import AuthCookies from '@/utils/authCookies';
 
 jest.mock('../../utils/api');
@@ -60,6 +61,7 @@ describe('GET function', () => {
 
     // Assertions
     expect(mockedCreateAuthenticatedApiConfiguration).toHaveBeenCalled();
+    expect(mockedUsersAPIApi.prototype.getUserByLoginId).toHaveBeenCalledWith(Constants.CLIENT_API_VERSION,"me");
     expect(mockedUsersAPIApi.prototype.getUserByLoginId).toHaveBeenCalledTimes(1); // Verify internal call
     expect(result.status).toBe(200); // Verify status code
     expect(bodyText).toBe(mockUserResponse); // Verify response body


### PR DESCRIPTION
# Why ?
The UI wanted to display the current user, but passed the wrong parameters to a function, 
so ended up querying all the users, got all the user records back, picked the top one and used that. Meaning everyone looked like they were logged-in as the same person who's name came alphabetically first.

The fix was to pass the `/users?loginId=me` query parameter properly, so that only the current users' ID is returned and displayed.

