### PR TITLE
Iss2007 - Trigger helm build to redeploy ecosystem1 after Web UI changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,6 +104,19 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 
+  trigger-workflow:
+    name: Trigger Helm workflow to recycle ecosystem1
+    needs: build-webui
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    steps:
+    - name: Trigger Helm workflow using GitHub CLI call
+      run: |
+        gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation
+      env:
+        GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+
   report-failure:
     name: Report failure in workflow
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2007

When changes are made to the Galasa Web UI, the services that deploy the Web UI such as ecosystem1 and prod1 need to be recycled so the Web UI changes are made available. This change triggers the Helm build which reinstalls the ecosystem1 service.