### PR TITLE
Iss2007 and Iss2085 - Recycle ecosystem1 after Web UI changes / Support forks in the workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,11 +17,13 @@ env:
 
 jobs:
   check-secrets:
-    name: Check the required secrets are set in this organisation
+    # Run this job for forks
+    if: ${{ github.repository_owner != 'galasa-dev' }}
+    name: Check for required secrets
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if WRITE_PACKAGES_USERNAME is set
+      - name: Check if WRITE_PACKAGES_USERNAME is set in this repository
         run: |
           if [ -z "${{ secrets.WRITE_PACKAGES_USERNAME }}" ]; then
             echo "WRITE_PACKAGES_USERNAME is not set. Please configure it in the repository secrets."
@@ -30,7 +32,7 @@ jobs:
             echo "WRITE_PACKAGES_USERNAME is set."
           fi
 
-      - name: Check if WRITE_PACKAGES_TOKEN is set
+      - name: Check if WRITE_PACKAGES_TOKEN is set in this repository
         run: |
           if [ -z "${{ secrets.WRITE_PACKAGES_TOKEN }}" ]; then
             echo "WRITE_PACKAGES_TOKEN is not set. Please configure it in the repository secrets."
@@ -60,7 +62,7 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
 
-      - name: Generate typescript openapi client using gradle
+      - name: Generate typescript openapi client using Gradle
         run: |
           gradle generateTypeScriptClient --info \
           --no-daemon --console plain \
@@ -130,28 +132,28 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   trigger-workflow:
-    # Skip this job for forks of this repository
+    # Skip this job for forks
     if: ${{ github.repository_owner == 'galasa-dev' }}
-    name: Trigger Helm workflow to recycle ecosystem1
+    name: Recycle ecosystem1
     needs: build-webui
     runs-on: ubuntu-latest
 
     steps:
-      - name: Trigger Helm workflow using GitHub CLI call
+      - name: Trigger Helm workflow using GitHub CLI
         env:
           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
         run: |
           gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation
 
   report-failure:
-    # Skip this job for forks of this repository
+    # Skip this job for forks
     if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
-    name: Report failure in workflow
+    name: Report workflow failure into Slack channel
     runs-on: ubuntu-latest
     needs: build-webui
 
     steps:
-      - name: Report failure in workflow to Slack
+      - name: Report workflow failure into Slack channel
         env: 
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
         run : |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  NAMESPACE: galasa-dev
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
 
 jobs:
   build-webui:
@@ -104,11 +105,27 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 
+  trigger-workflow:
+    name: Trigger Helm workflow to recycle ecosystem1
+    needs: build-webui
+    runs-on: ubuntu-latest
+    # Skip this job for forks of this repository
+    if: ${{ github.repository_owner == 'galasa-dev' }}
+    permissions: write-all
+
+    steps:
+    - name: Trigger Helm workflow using GitHub CLI call
+      run: |
+        gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation
+      env:
+        GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+
   report-failure:
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: build-webui
-    if: failure()
+    # Skip this job for forks of this repository
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,9 +16,33 @@ env:
   BRANCH: ${{ github.ref_name }}
 
 jobs:
+  check-secrets:
+    name: Check the required secrets are set in this organisation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if WRITE_PACKAGES_USERNAME is set
+        run: |
+          if [ -z "${{ secrets.WRITE_PACKAGES_USERNAME }}" ]; then
+            echo "WRITE_PACKAGES_USERNAME is not set. Please configure it in the repository secrets."
+            exit 1
+          else
+            echo "WRITE_PACKAGES_USERNAME is set."
+          fi
+
+      - name: Check if WRITE_PACKAGES_TOKEN is set
+        run: |
+          if [ -z "${{ secrets.WRITE_PACKAGES_TOKEN }}" ]; then
+            echo "WRITE_PACKAGES_TOKEN is not set. Please configure it in the repository secrets."
+            exit 1
+          else
+            echo "WRITE_PACKAGES_TOKEN is set."
+          fi
+
   build-webui:
     name: Build the Galasa Web UI
     runs-on: ubuntu-latest
+    needs: check-secrets
 
     steps:
       - name: Checkout Code
@@ -41,7 +65,7 @@ jobs:
           gradle generateTypeScriptClient --info \
           --no-daemon --console plain \
           -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr 2>&1 | tee build.log
-      
+
       - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
@@ -71,12 +95,12 @@ jobs:
         working-directory: ./galasa-ui
         run: |
           npm install
-      
+
       - name: Running webui's unit tests using npm
         working-directory: ./galasa-ui
         run: |
           npm test -- --watchAll=false
-      
+
       - name: Building webui using npm
         working-directory: ./galasa-ui
         run: |
@@ -86,15 +110,15 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: galasa-team
-          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-  
+          username: ${{ secrets.WRITE_PACKAGES_USERNAME }}
+          password: ${{ secrets.WRITE_PACKAGES_TOKEN }}
+
       - name: Extract metadata for webui image
         id: metadata
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/webui
-  
+
       - name: Build Webui image
         id: build
         uses: docker/build-push-action@v5
@@ -106,26 +130,25 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
 
   trigger-workflow:
+    # Skip this job for forks of this repository
+    if: ${{ github.repository_owner == 'galasa-dev' }}
     name: Trigger Helm workflow to recycle ecosystem1
     needs: build-webui
     runs-on: ubuntu-latest
-    # Skip this job for forks of this repository
-    if: ${{ github.repository_owner == 'galasa-dev' }}
-    permissions: write-all
 
     steps:
-    - name: Trigger Helm workflow using GitHub CLI call
-      run: |
-        gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation
-      env:
-        GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+      - name: Trigger Helm workflow using GitHub CLI call
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation
 
   report-failure:
+    # Skip this job for forks of this repository
+    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
     name: Report failure in workflow
     runs-on: ubuntu-latest
     needs: build-webui
-    # Skip this job for forks of this repository
-    if: ${{ failure() && github.repository_owner == 'galasa-dev' }}
 
     steps:
       - name: Report failure in workflow to Slack

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,22 +23,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check if WRITE_PACKAGES_USERNAME is set in this repository
+      - name: Check if WRITE_GITHUB_PACKAGES_USERNAME is set in this repository
         run: |
-          if [ -z "${{ secrets.WRITE_PACKAGES_USERNAME }}" ]; then
-            echo "WRITE_PACKAGES_USERNAME is not set. Please configure it in the repository secrets."
+          if [ -z "${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}" ]; then
+            echo "WRITE_GITHUB_PACKAGES_USERNAME is not set. Please configure it in the repository secrets."
             exit 1
           else
-            echo "WRITE_PACKAGES_USERNAME is set."
+            echo "WRITE_GITHUB_PACKAGES_USERNAME is set."
           fi
 
-      - name: Check if WRITE_PACKAGES_TOKEN is set in this repository
+      - name: Check if WRITE_GITHUB_PACKAGES_TOKEN is set in this repository
         run: |
-          if [ -z "${{ secrets.WRITE_PACKAGES_TOKEN }}" ]; then
-            echo "WRITE_PACKAGES_TOKEN is not set. Please configure it in the repository secrets."
+          if [ -z "${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}" ]; then
+            echo "WRITE_GITHUB_PACKAGES_TOKEN is not set. Please configure it in the repository secrets."
             exit 1
           else
-            echo "WRITE_PACKAGES_TOKEN is set."
+            echo "WRITE_GITHUB_PACKAGES_TOKEN is set."
           fi
 
   build-webui:
@@ -112,8 +112,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.WRITE_PACKAGES_USERNAME }}
-          password: ${{ secrets.WRITE_PACKAGES_TOKEN }}
+          username: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+          password: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
 
       - name: Extract metadata for webui image
         id: metadata

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,8 @@ jobs:
       - name: Check if WRITE_GITHUB_PACKAGES_USERNAME is set in this repository
         run: |
           if [ -z "${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}" ]; then
-            echo "WRITE_GITHUB_PACKAGES_USERNAME is not set. Please configure it in the repository secrets."
+            echo "WRITE_GITHUB_PACKAGES_USERNAME is not set. Please configure it in the repository secrets. \
+            It must contain the GitHub username you want to use to log into GitHub Container Registry."
             exit 1
           else
             echo "WRITE_GITHUB_PACKAGES_USERNAME is set."
@@ -35,7 +36,9 @@ jobs:
       - name: Check if WRITE_GITHUB_PACKAGES_TOKEN is set in this repository
         run: |
           if [ -z "${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}" ]; then
-            echo "WRITE_GITHUB_PACKAGES_TOKEN is not set. Please configure it in the repository secrets."
+            echo "WRITE_GITHUB_PACKAGES_TOKEN is not set. Please configure it in the repository secrets. \
+            It must contain a GitHub Personal Access Token with write:packages scope \
+            that you want to use to log into GitHub Container Registry.""
             exit 1
           else
             echo "WRITE_GITHUB_PACKAGES_TOKEN is set."

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -10,9 +10,21 @@ on:
     branches: [main]
 
 jobs:
+  detect-secrets:
+    name: Detect secrets in this Pull Request
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Turn script into an executable
+        run: chmod +x detect-secrets.sh
+
+      - name: Run the detect secrets script
+        run: ./detect-secrets.sh
+
   build-webui:
     name: Build the Galasa Web UI
     runs-on: ubuntu-latest
+    needs: detect-secrets
 
     steps:
       - name: Checkout Code
@@ -30,13 +42,13 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
 
-      - name: Generate typescript openapi client using gradle
+      - name: Generate typescript openapi client using Gradle
         run: |
           set -o pipefail
           gradle generateTypeScriptClient --info \
           --no-daemon --console plain \
           -PsourceMaven=https://development.galasa.dev/main/maven-repo/obr 2>&1 | tee build.log
-      
+
       - name: Upload Gradle build log
         if: failure()
         uses: actions/upload-artifact@v4
@@ -44,7 +56,7 @@ jobs:
           name: gradle-build-log
           path: build.log
           retention-days: 7
-          
+
       - name: Fix openapi client
         run: |
           mkdir -p temp &&
@@ -61,28 +73,22 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "20.10.0"
-      
-      - name: Turn script into an executable
-        run: chmod +x detect-secrets.sh
-  
-      - name: Run the detect secrets script
-        run: ./detect-secrets.sh
 
       - name: Installing webui's dependencies using npm
         working-directory: ./galasa-ui
         run: |
           npm install
-      
+
       - name: Running webui's unit tests using npm
         working-directory: ./galasa-ui
         run: |
           npm test -- --watchAll=false
-      
+
       - name: Building webui using npm
         working-directory: ./galasa-ui
         run: |
           npm run build
-      
+
       - name: Build Webui image for testing
         id: build
         uses: docker/build-push-action@v5

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Turn script into an executable
         run: chmod +x detect-secrets.sh
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2007 and https://github.com/galasa-dev/projectmanagement/issues/2085.

- (Iss2007) Trigger the Helm workflow which redeploys ecosystem1 following changes to the WebUI. (Iss2085) Only call this if the build is from the galasa-dev organisation, so this doesn't fail forked repos builds of the WebUI.
- (Iss2085) For forks, run a job before attempting to start the build that checks for the presence of the required secrets. If they haven't been set up, the build fails and tells the forked user to set up the secrets in the repo.
- (Iss2085) Update the secret names from `GALASA_TEAM_WRITE_PACKAGES_TOKEN` to just `WRITE_PACKAGES_TOKEN` as galasa team is only specific to when the workflow is running in galasa-dev, not relevant for forks.
- Move detect-secrets to separate job from the PR build.