### PR TITLE
Fix typo that broke script in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
           if [ -z "${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}" ]; then
             echo "WRITE_GITHUB_PACKAGES_TOKEN is not set. Please configure it in the repository secrets. \
             It must contain a GitHub Personal Access Token with write:packages scope \
-            that you want to use to log into GitHub Container Registry.""
+            that you want to use to log into GitHub Container Registry."
             exit 1
           else
             echo "WRITE_GITHUB_PACKAGES_TOKEN is set."


### PR DESCRIPTION
PR #77 had a typo that caused an EOF failure in a step in the workflow.