### PR TITLE
Update call to reusable workflow, pass secrets explicitly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,10 +19,12 @@ jobs:
   check-required-secrets-configured:
     name: Check required secrets configured
     uses: galasa-dev/galasa/.github/workflows/check-required-secrets-configured.yaml@main
-    secrets: inherit
     with:
-      write_github_packages_username: 'true'
-      write_github_packages_token: 'true'
+      check_write_github_packages_username: 'true'
+      check_write_github_packages_token: 'true'
+    secrets:
+      WRITE_GITHUB_PACKAGES_USERNAME: ${{ secrets.WRITE_GITHUB_PACKAGES_USERNAME }}
+      WRITE_GITHUB_PACKAGES_TOKEN: ${{ secrets.WRITE_GITHUB_PACKAGES_TOKEN }}
 
   build-webui:
     name: Build the Galasa Web UI


### PR DESCRIPTION
## Why?

Corrections made as per this PR: https://github.com/galasa-dev/galasa/pull/147