### PR TITLE
Bump development version to 0.42.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaFrameworkVersion = "0.41.0"
+def galasaFrameworkVersion = "0.42.0"
 def galasaOpenApiYamlVersion = galasaFrameworkVersion
 
 repositories {

--- a/galasa-ui/src/utils/constants.ts
+++ b/galasa-ui/src/utils/constants.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-const CLIENT_API_VERSION = "0.41.0";
+const CLIENT_API_VERSION = "0.42.0";
 
 
 export {CLIENT_API_VERSION};


### PR DESCRIPTION
For https://github.com/galasa-dev/projectmanagement/issues/2171

Note: Builds for this PR will fail until https://github.com/galasa-dev/galasa/pull/284 is delivered