### PR TITLE
Add a mechanism to allow developers to connect their local webui with a remote Galasa service backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Don't ever check-in node modules..
 **/node_modules/
 
@@ -41,3 +40,6 @@ build/
 
 # Ignore temp directories
 **/temp/
+
+# Ignore local env files
+.env*.local

--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ This is the home of the web user-interface for Galasa.
 
 If you would like to run the web UI locally and have it connect to an existing Galasa service's backend, perform the following steps:
 
-1. Navigate to the remote Galasa service's webui and create a new personal access token. The personal access token value will be in the form `<string>:<string>` - note this token value down
-2. Set the `GALASA_DEV_TOKEN` environment variable, either in the terminal that you will use to start the webui or inside a new `.env.development.local` file, to be the personal access token that was just created
+1. Make sure that you have access to an existing Galasa service and are able to log in to its web UI - if you do not have access, contact your Galasa service administrator
+2. Navigate to the remote Galasa service's webui and create a new personal access token. The personal access token value will be in the form `<string>:<string>` - note this token value down
+3. Set the `GALASA_DEV_TOKEN` environment variable, either in the terminal that you will use to start the webui or inside a new `.env.development.local` file, to be the personal access token that was just created
     - For example, if your access token was `my:token`, you could create a new `.env.development.local` file next to the existing `.env` file and then set the environment variable in the file like `GALASA_DEV_TOKEN="my:token"`
-3. Set the `GALASA_API_SERVER_URL` environment variable, either in the same terminal that you will use to start the webui or inside the `.env.development.local` file that you may have created in step 2, to be the URL of the remote Galasa service's API server
+4. Set the `GALASA_API_SERVER_URL` environment variable, either in the same terminal that you will use to start the webui or inside the `.env.development.local` file that you may have created in step 3, to be the URL of the remote Galasa service's API server
     - For example, if the Galasa service's webui URL was `https://my-galasa-service.dev`, then the API server URL would be `https://my-galasa-service.dev/api` (added `/api` to the end of the URL)
-4. Start the webui locally
+5. Start the webui locally
 
 ## How to contribute
 See the [contributions.md](./CONTRIBUTIONS.md) file for terms and instructions.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,16 @@ This is the home of the web user-interface for Galasa.
 ## To run development server locally
 - Run the `run-locally.sh` script
 
-## To build docker image locally
-- Run the `build-container-locally.sh` script
+## Connecting the local development web UI with a remote API server
 
-## To run docker image locally
-- Run the `run-container-locally.sh` script
+If you would like to run the web UI locally and have it connect to an existing Galasa service's backend, perform the following steps:
+
+1. Navigate to the remote Galasa service's webui and create a new personal access token. The personal access token value will be in the form `<string>:<string>` - note this token value down
+2. Set the `GALASA_DEV_TOKEN` environment variable, either in the terminal that you will use to start the webui or inside a new `.env.development.local` file, to be the personal access token that was just created
+    - For example, if your access token was `my:token`, you could create a new `.env.development.local` file next to the existing `.env` file and then set the environment variable in the file like `GALASA_DEV_TOKEN="my:token"`
+3. Set the `GALASA_API_SERVER_URL` environment variable, either in the same terminal that you will use to start the webui or inside the `.env.development.local` file that you may have created in step 2, to be the URL of the remote Galasa service's API server
+    - For example, if the Galasa service's webui URL was `https://my-galasa-service.dev`, then the API server URL would be `https://my-galasa-service.dev/api` (added `/api` to the end of the URL)
+4. Start the webui locally
 
 ## How to contribute
 See the [contributions.md](./CONTRIBUTIONS.md) file for terms and instructions.

--- a/galasa-ui/.env
+++ b/galasa-ui/.env
@@ -1,5 +1,25 @@
-# Environment variables used for authentication and interacting with the Galasa API server
+# .env - This file outlines the environment variables that the webui uses.
+# Important: Do NOT enter any sensitive information like auth tokens into this file.
+# Instead, create a copy of this file with .local suffixed to it (e.g. .env.development.local)
+# and edit that file however you wish as it will be ignored by git.
+# See https://nextjs.org/docs/app/guides/environment-variables for more details as to how Next.js loads environment variables.
+
+# --- Environment variables used for authentication and interacting with the Galasa API server ---
+#
+# The URL of the API server that the webui should interact with.
 GALASA_API_SERVER_URL="http://localhost:8080"
+#
+# The external URL of this webui.
 GALASA_WEBUI_HOST_URL="http://localhost:3000"
+#
+# The client ID of this webui to associate with Dex's known clients.
 GALASA_WEBUI_CLIENT_ID="galasa-webui"
+#
+# The name of the Galasa service. This text will appear on the webui's menu bar.
 GALASA_SERVICE_NAME=""
+#
+# For development use only. If you would like to start the webui locally and have it connect to a remote Galasa service's API server,
+# set the GALASA_DEV_TOKEN value to be a Galasa access token that was created using the remote Galasa service's webui.
+#
+# Make sure that the "GALASA_API_SERVER_URL" env variable is set to the correct Galasa service's API server.
+GALASA_DEV_TOKEN=""

--- a/galasa-ui/src/tests/myprofile.test.tsx
+++ b/galasa-ui/src/tests/myprofile.test.tsx
@@ -6,7 +6,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import MyProfilePage from '../app/myprofile/page';
-import { RBACRole, RoleBasedAccessControlAPIApi, UsersAPIApi } from '@/generated/galasaapi';
+import { RBACRole, UsersAPIApi } from '@/generated/galasaapi';
 
 const mockUsersApi = UsersAPIApi as jest.Mock;
 

--- a/galasa-ui/src/tests/routes/authTokens.test.ts
+++ b/galasa-ui/src/tests/routes/authTokens.test.ts
@@ -5,7 +5,7 @@
  * @jest-environment node
  */
 import * as AuthTokenRoute from '@/app/auth/tokens/route';
-import { AuthenticationAPIApi, UsersAPIApi } from '@/generated/galasaapi';
+import { AuthenticationAPIApi } from '@/generated/galasaapi';
 import { NextRequest} from 'next/server';
 
 const mockAuthenticationApi = AuthenticationAPIApi as jest.Mock;

--- a/galasa-ui/src/tests/routes/users.test.ts
+++ b/galasa-ui/src/tests/routes/users.test.ts
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { UsersAPIApi } from '@/generated/galasaapi';
 import { DELETE } from '../../app/logout/route';
-import { createAuthenticatedApiConfiguration } from '../../utils/api';
 import AuthCookies from '@/utils/authCookies';
 
 // Mock modules and dependencies
@@ -42,10 +40,6 @@ jest.mock('next/server', () => {
     NextResponse: MockNextResponse,
   };
 });
-
-// Define the type for the mocked function
-const mockedCreateAuthenticatedApiConfiguration = createAuthenticatedApiConfiguration as jest.MockedFunction<typeof createAuthenticatedApiConfiguration>;
-const mockedUsersAPIApi = UsersAPIApi as jest.MockedClass<typeof UsersAPIApi>;
 
 const deleteMock = jest.fn();
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2248

## Changes
- Added `GALASA_DEV_TOKEN` env variable so that a personal access token can be used to authenticate with a remote Galasa service instead of redirecting to Dex
- Updated middleware to handle authenticating with a personal access token in **development mode only**
- Updated README on how to connect a local webui with a remote API server
- Added comments to the .env file to clarify each env variable and the purpose of the file
- Added unit tests and removed unused imports from existing unit tests