### PR TITLE
Mock out calls to the API server in layout unit tests and fix more unit test warnings 

### DIFF
--- a/galasa-ui/src/components/headers/PageHeader.tsx
+++ b/galasa-ui/src/components/headers/PageHeader.tsx
@@ -30,7 +30,7 @@ export default function PageHeader({ galasaServiceName }: { galasaServiceName: s
 
         <HeaderName href="/" prefix="">Galasa</HeaderName>
 
-        <HeaderNavigation>
+        <HeaderNavigation aria-label="Galasa menu bar navigation">
           <HeaderMenuItem href="/users">Users</HeaderMenuItem>
         </HeaderNavigation>
 

--- a/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Layout renders the web UI layout 1`] = `
                 Galasa
               </a>
               <nav
+                aria-label="Galasa menu bar navigation"
                 class="cds--header__nav"
               >
                 <ul
@@ -150,6 +151,7 @@ exports[`Layout renders the web UI layout 1`] = `
             >
               <p>
                 Galasa version 
+                my-galasa-version
               </p>
               <p
                 class="serviceHealthTitle"
@@ -216,6 +218,7 @@ exports[`Layout renders the web UI layout 1`] = `
               Galasa
             </a>
             <nav
+              aria-label="Galasa menu bar navigation"
               class="cds--header__nav"
             >
               <ul
@@ -311,6 +314,7 @@ exports[`Layout renders the web UI layout 1`] = `
           >
             <p>
               Galasa version 
+              my-galasa-version
             </p>
             <p
               class="serviceHealthTitle"

--- a/galasa-ui/src/tests/myprofile.test.tsx
+++ b/galasa-ui/src/tests/myprofile.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import MyProfilePage from '../app/myprofile/page';
 import { RBACRole, UsersAPIApi } from '@/generated/galasaapi';
 
@@ -17,7 +17,7 @@ describe('MyProfilePage', () => {
     jest.clearAllMocks();
   });
 
-  test('renders loading spinner initially', () => {
+  test('renders loading spinner initially', async () => {
     // When...
     render(<MyProfilePage />);
 
@@ -52,7 +52,9 @@ describe('MyProfilePage', () => {
     });
 
     // When...
-    render(<MyProfilePage />);
+    await act(async () => {
+      return render(<MyProfilePage />);
+    });
 
     // Wait for the data to be fetched and the loading spinner to disappear
     await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());
@@ -70,7 +72,9 @@ describe('MyProfilePage', () => {
     });
 
     // When...
-    render(<MyProfilePage />);
+    await act(async () => {
+      return render(<MyProfilePage />);
+    });
 
     // Wait for the fetch operation to complete
     await waitFor(() => expect(screen.queryByTestId('loader')).not.toBeInTheDocument());


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2240

## Changes
- Mocked out API calls to the /bootstrap and /openapi endpoints in the RootLayout unit tests
- Fixed various warnings appearing in unit tests:
  - HeaderNavigation was complaining about not having an `aria-label` set, so added one
  - RootLayout and MyProfilePage tests were complaining about not having `render` wrapped in an `act` due to useEffect updates taking place