### PR TITLE
Pass in the correct callback URL when redirecting back from login page

### DIFF
--- a/galasa-ui/src/middleware.ts
+++ b/galasa-ui/src/middleware.ts
@@ -57,7 +57,7 @@ export async function middleware(request: NextRequest) {
       } else if (!isAuthenticated(request)) {
   
         // Force the user to re-authenticate, getting the URL to redirect to and any cookies to be set
-        const authResponse = await sendAuthRequest(GALASA_WEBUI_CLIENT_ID);
+        const authResponse = await sendAuthRequest(GALASA_WEBUI_CLIENT_ID, `${request.url}/callback`);
         const locationHeader = authResponse.headers.get('Location');
         if (locationHeader) {
           response = NextResponse.redirect(locationHeader, { status: 302 });

--- a/galasa-ui/src/tests/middleware.test.ts
+++ b/galasa-ui/src/tests/middleware.test.ts
@@ -41,24 +41,32 @@ describe('Middleware', () => {
 
   it('should redirect to authenticate if the user does not have a JWT', async () => {
     // Given...
-    const req = new NextRequest(new Request('https://galasa-ecosystem.com/runs'), {});
+    const requestUrl = 'https://galasa-ecosystem.com/runs';
+    const req = new NextRequest(new Request(requestUrl), {});
     const redirectUrl = 'http://my-connector/auth';
 
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        url: redirectUrl,
-        headers: {
-          get: jest.fn().mockReturnValue(redirectUrl),
-        },
-      })
-    ) as jest.Mock;
+    const fetchSpy = jest.spyOn(global, "fetch")
+      .mockImplementation(jest.fn(() =>
+        Promise.resolve({
+          url: redirectUrl,
+          headers: {
+            get: jest.fn().mockReturnValue(redirectUrl),
+          },
+        })
+      ) as jest.Mock);
 
     // When...
     await middleware(req);
 
     // Then...
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(redirectSpy).toHaveBeenCalledTimes(1);
     expect(redirectSpy).toHaveBeenCalledWith(redirectUrl, { status: 302 });
+
+    // Fetch calls take the form 'fetch(<url>, <request-init>)', so get the URL that was passed in
+    const fetchedUrl = fetchSpy.mock.calls[0][0];
+    expect(fetchedUrl.toString()).toContain(`callback_url=${requestUrl}/callback`);
+    fetchSpy.mockRestore();
   });
 
   it('should redirect to authenticate if the issued JWT has expired in the past', async () => {


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2251

## Changes
- When the redirects to authenticate with Dex, the web UI now passes in the original request's URL as a callback URL so that the user gets redirected back to the correct page after logging in (this callback URL previously defaulted to the web UI's home page).