### PR TITLE
Pass in the correct callback URL when redirecting back from login page 

### DIFF
--- a/galasa-ui/src/middleware.ts
+++ b/galasa-ui/src/middleware.ts
@@ -57,7 +57,7 @@ export async function middleware(request: NextRequest) {
       } else if (!isAuthenticated(request)) {
   
         // Force the user to re-authenticate, getting the URL to redirect to and any cookies to be set
-        const authResponse = await sendAuthRequest(GALASA_WEBUI_CLIENT_ID);
+        const authResponse = await sendAuthRequest(GALASA_WEBUI_CLIENT_ID, `${request.url}/callback`);
         const locationHeader = authResponse.headers.get('Location');
         if (locationHeader) {
           response = NextResponse.redirect(locationHeader, { status: 302 });

--- a/galasa-ui/src/middleware.ts
+++ b/galasa-ui/src/middleware.ts
@@ -75,17 +75,22 @@ export async function middleware(request: NextRequest) {
   return response;
 }
 
+// Returns a string representing the URL to return back to after authenticating.
 const getRequestCallbackUrl = (requestedPath: string) => {
+  // Remove the trailing '/' from the host URL and requested path if there is one
   let hostUrl = GALASA_WEBUI_HOST_URL;
   if (hostUrl.endsWith('/')) {
-    hostUrl = hostUrl.slice(0, hostUrl.length);
+    hostUrl = hostUrl.substring(0, hostUrl.length - 1);
   }
 
   let pathName = requestedPath;
-  if (pathName !== '/' && pathName.endsWith('/')) {
-    pathName = pathName.slice(0, pathName.length);
+  if (pathName === '/') {
+    pathName = "";
+  } else if (pathName.endsWith('/')) {
+    pathName = pathName.substring(0, pathName.length - 1);
   }
 
+  // The request path is expected to start with a '/' if a non-root path is requested
   const callbackUrl = `${hostUrl}${pathName}/callback`;
   return callbackUrl;
 };

--- a/galasa-ui/src/tests/middleware.test.ts
+++ b/galasa-ui/src/tests/middleware.test.ts
@@ -41,24 +41,32 @@ describe('Middleware', () => {
 
   it('should redirect to authenticate if the user does not have a JWT', async () => {
     // Given...
-    const req = new NextRequest(new Request('https://galasa-ecosystem.com/runs'), {});
+    const requestUrl = 'https://galasa-ecosystem.com/runs';
+    const req = new NextRequest(new Request(requestUrl), {});
     const redirectUrl = 'http://my-connector/auth';
 
-    global.fetch = jest.fn(() =>
-      Promise.resolve({
-        url: redirectUrl,
-        headers: {
-          get: jest.fn().mockReturnValue(redirectUrl),
-        },
-      })
-    ) as jest.Mock;
+    const fetchSpy = jest.spyOn(global, "fetch")
+      .mockImplementation(jest.fn(() =>
+        Promise.resolve({
+          url: redirectUrl,
+          headers: {
+            get: jest.fn().mockReturnValue(redirectUrl),
+          },
+        })
+      ) as jest.Mock);
 
     // When...
     await middleware(req);
 
     // Then...
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(redirectSpy).toHaveBeenCalledTimes(1);
     expect(redirectSpy).toHaveBeenCalledWith(redirectUrl, { status: 302 });
+
+    // Fetch calls take the form 'fetch(<url>, <request-init>)', so get the URL that was passed in
+    const fetchedUrl = fetchSpy.mock.calls[0][0];
+    expect(fetchedUrl.toString()).toContain(`callback_url=${requestUrl}/callback`);
+    fetchSpy.mockRestore();
   });
 
   it('should redirect to authenticate if the issued JWT has expired in the past', async () => {

--- a/galasa-ui/src/tests/middleware.test.ts
+++ b/galasa-ui/src/tests/middleware.test.ts
@@ -9,6 +9,11 @@ import { NextRequest, NextResponse } from 'next/server';
 
 const originalEnv = process.env;
 
+jest.mock('@/utils/auth', () => ({
+  ...jest.requireActual('@/utils/auth'),
+  GALASA_WEBUI_HOST_URL: "http://mock-webui-host-url",
+}));
+
 // Mock the jwtDecode method
 jest.mock('jwt-decode', () => ({
   __esModule: true,
@@ -65,7 +70,7 @@ describe('Middleware', () => {
 
     // Fetch calls take the form 'fetch(<url>, <request-init>)', so get the URL that was passed in
     const fetchedUrl = fetchSpy.mock.calls[0][0];
-    expect(fetchedUrl.toString()).toContain(`callback_url=${requestUrl}/callback`);
+    expect(fetchedUrl.toString()).toContain(`callback_url=http://mock-webui-host-url/runs/callback`);
     fetchSpy.mockRestore();
   });
 

--- a/galasa-ui/src/utils/auth.ts
+++ b/galasa-ui/src/utils/auth.ts
@@ -7,7 +7,7 @@
 import { AuthenticationAPIApi } from '@/generated/galasaapi';
 import { createApiConfiguration, GALASA_API_SERVER_URL} from './api';
 
-const GALASA_WEBUI_HOST_URL = process.env.GALASA_WEBUI_HOST_URL ?? '';
+export const GALASA_WEBUI_HOST_URL = process.env.GALASA_WEBUI_HOST_URL ?? '';
 
 export const GALASA_WEBUI_CLIENT_ID = process.env.GALASA_WEBUI_CLIENT_ID ?? 'galasa-webui';
 


### PR DESCRIPTION
## Why?
See https://github.com/galasa-dev/projectmanagement/issues/2251

## Changes
- When the redirects to authenticate with Dex, the web UI now passes in a callback URL that points to the webui's external URL with the requested path so that the user gets redirected back to the correct page after logging in.