### PR TITLE
fix(i18n): Address internationalization snags and inconsistencies

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -111,6 +111,9 @@
     "home": "Startseite",
     "users": "Benutzer"
   },
+  "BreadCrumb": {
+    "home": "Startseite"
+  },
   "AccessDeniedModal": {
     "modalHeading": "Unzureichende Berechtigungen",
     "logoutButton": "Abmelden",
@@ -125,7 +128,6 @@
   },
   "TestRun": {
     "title": "Testläufe",
-    "underConstruction": "Diese Seite befindet sich im Aufbau. Bitte später wiederkommen.",
     "status": "Wird geladen..."
   },
   "MySettings": {
@@ -164,7 +166,7 @@
     "filter_info": "Info",
     "filter_debug": "Debug",
     "filter_trace": "Trace",
-    "download_button": "Protokoll herunterladen"
+    "download_button": "Laufprotokoll herunterladen"
   },
   "MethodsTab": {
     "title": "Methoden",
@@ -198,7 +200,7 @@
     "tabs": {
       "overview": "Übersicht",
       "methods": "Methoden",
-      "runLog": "Protokoll",
+      "runLog": "Laufprotokoll",
       "artifacts": "Artefakte"
     }
   },
@@ -209,13 +211,13 @@
     "tabs": {
       "overview": "Übersicht",
       "methods": "Methoden",
-      "runLog": "Protokoll",
+      "runLog": "Laufprotokoll",
       "artifacts": "Artefakte"
     }
   },
   "TestRunsTable": {
     "submittedAt": "Eingereicht am",
-    "testRunName": "Testlaufname",
+    "testRunName": "Name des Testlaufs",
     "requestor": "Anforderer",
     "group": "Gruppe",
     "bundle": "Bundle",
@@ -226,7 +228,7 @@
     "result": "Ergebnis",
     "submissionId":"Übermittlungs-ID",
     "noTestRunsFound": "Für den ausgewählten Zeitraum wurden keine Testläufe gefunden",
-    "loading": "Testergebnisse werden geladen...",
+    "isloading": "Testergebnisse werden geladen...",
     "limitExceededTitle": "Limit überschritten",
     "limitExceededSubtitle": "Ihre Abfrage ergab mehr als {maxRecords} Ergebnisse. Es werden die ersten {maxRecords} Datensätze angezeigt.",
     "timeFrameText": {
@@ -237,7 +239,11 @@
       "backwardText": "Vorherige Seite",
       "forwardText": "Nächste Seite",
       "itemsPerPageText": "Einträge pro Seite:",
-      "pageNumberText": "Seitennummer"
+      "pageNumberText": "Seitennummer",
+      "of": "von",
+      "items": "Einträge",
+      "pages": "Seiten",
+      "page": "Seite"
     }
   },
   "TestRunsTabs": {

--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -191,7 +191,7 @@
     "noTags": "Keine Tags vorhanden."
   },
   "TestRunDetails": {
-    "title": "Testlauf:",
+    "title": "Testlauf: {runName}",
     "status": "Status",
     "result": "Ergebnis",
     "test": "Test",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -229,7 +229,7 @@
     "result": "Result",
     "submissionId": "Submission ID",
     "noTestRunsFound": "No test runs were found for the selected timeframe",
-    "loading": "Loading test results...",
+    "isloading":"Loading test results...",
     "limitExceededTitle": "Limit Exceeded",
     "limitExceededSubtitle": "Your query returned more than {maxRecords} results. Showing the first {maxRecords} records.",
     "timeFrameText": {

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -194,7 +194,7 @@
     "noTags": "No tags were associated with this test run."
   },
   "TestRunDetails": {
-    "title": "Test Run:",
+    "title": "Test Run: {runName}",
     "status": "Status",
     "result": "Result",
     "test": "Test",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -128,7 +128,6 @@
   },
   "TestRun": {
     "title": "Test Runs",
-    "underConstruction": "This page is under construction. Please come back later to query a list of test runs.",
     "status": "Loading..."
   },
   "MySettings": {
@@ -240,7 +239,11 @@
       "backwardText": "Previous page",
       "forwardText": "Next page",
       "itemsPerPageText": "Items per page:",
-      "pageNumberText": "Page Number"
+      "pageNumberText": "Page Number",
+      "of": "of",
+      "items":"items",
+      "pages":"pages",
+      "page":"page"
     }
   },
   "TestRunsTabs": {

--- a/galasa-ui/public/static/markdown/home-contents.de.md
+++ b/galasa-ui/public/static/markdown/home-contents.de.md
@@ -1,0 +1,6 @@
+# Willkommen bei Ihrem Galasa Dienst
+Nutzen Sie Galasa optimal, indem Sie die [Galasa-Dokumentation](https://galasa.dev/) lesen.
+
+Um diesen Text anzupassen, wenden Sie sich bitte an Ihren Servicetechniker oder Administrator, um die Konfigurationseigenschaft `service.welcome.markdown` festzulegen.
+
+![Abstraktes Bild von Testkugeln, die in bestanden oder nicht bestanden sortiert werden!](https://raw.githubusercontent.com/galasa-dev/webui/refs/heads/main/galasa-ui/public/static/homeGraphic.svg)

--- a/galasa-ui/src/app/page.tsx
+++ b/galasa-ui/src/app/page.tsx
@@ -12,9 +12,9 @@ import { MarkdownResponse } from "@/utils/interfaces";
 import { readFile } from "fs/promises";
 import { getLocale } from "next-intl/server";
 import { getMarkdownFilePath } from "@/utils/markdown";
-import path from "path";
 
-export default function HomePage() {
+export default async function HomePage() {
+  const locale = await getLocale() || "en";
   // Fetches the content contained in the service.welcome.markdown CPS property from the API server
   // Overrides the default markdown content present in /public/static/markdown/home-contents.md
   const fetchHomePageContentFromCps = async (): Promise<MarkdownResponse> => {
@@ -60,13 +60,10 @@ export default function HomePage() {
       responseStatusCode: 200
     };
     try {
-      // Fetch the markdown file from the public/static folder
-      const defaultContentFilePath = path.join(process.cwd(), "public", "static", "markdown", "home-contents.md");
       content = {
         markdownContent: await readFile(getMarkdownFilePath(locale), 'utf-8'),
         responseStatusCode: 200
       };
-
     } catch (error) {
       console.error('Error fetching or processing the default markdown contents', error);
       throw error;

--- a/galasa-ui/src/components/headers/PageHeaderMenu.tsx
+++ b/galasa-ui/src/components/headers/PageHeaderMenu.tsx
@@ -14,6 +14,7 @@ import LanguageSelector from './LanguageSelector';
 import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
 import { FEATURE_FLAGS } from '@/utils/featureFlags';
 import { useTranslations } from 'next-intl';
+import { setUserLocale } from '@/utils/locale';
 
 function PageHeaderMenu({ galasaServiceName }: { galasaServiceName: string }) {
   const translations = useTranslations('PageHeaderMenu');
@@ -29,6 +30,9 @@ function PageHeaderMenu({ galasaServiceName }: { galasaServiceName: string }) {
   };
   const {isFeatureEnabled} = useFeatureFlags();
   
+  if(!isFeatureEnabled(FEATURE_FLAGS.INTERNATIONALIZATION)) {
+    setUserLocale("en");
+  }
   return (
     <HeaderGlobalBar data-testid="header-menu">
 

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -173,7 +173,7 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
   if (isLoading) {
     return (
       <div>
-        <p className={styles.timeFrameText}>{translations("loading")}</p>
+        <p className={styles.timeFrameText}>{translations("isloading")}</p>
         <DataTableSkeleton
           data-testid="loading-table-skeleton"
           columnCount={headers.length}
@@ -199,8 +199,8 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
     router.push(`/test-runs/${runId}`);
   };
 
-  if( !tableRows || tableRows.length === 0) {
-    return <p>No test runs were found for the selected timeframe</p>;
+  if ( !tableRows || tableRows.length === 0) {
+    return <p>{translations('noTestRunsFound')}</p>;
   }
 
   return (

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -254,6 +254,8 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
           backwardText={translations("pagination.backwardText")}
           forwardText={translations("pagination.forwardText")}
           itemsPerPageText={translations("pagination.itemsPerPageText")}
+          itemRangeText={(min:number, max:number, total:number) =>`${min}–${max} ${translations("pagination.of")} ${total} ${translations("pagination.items")}`}
+          pageRangeText={(total:number) =>`${translations("pagination.of")} ${total} ${translations("pagination.pages")}`}
           pageNumberText={translations("pagination.pageNumberText")}
           page={currentPage}
           pageSize={pageSize}

--- a/galasa-ui/src/styles/HomeContent.module.css
+++ b/galasa-ui/src/styles/HomeContent.module.css
@@ -5,7 +5,7 @@
  */
 
 .homeContentWrapper{
-    width: 90%;
+    max-width: 650px; 
     height: 100%;
     margin: 4rem auto;
     display: grid;

--- a/galasa-ui/src/styles/MySettings.module.css
+++ b/galasa-ui/src/styles/MySettings.module.css
@@ -37,6 +37,8 @@
 
 .deleteBtn {
     margin-left: 1rem !important;
+    text-align: center !important;
+    padding: 0.6rem 1rem !important;
 }
 
 .title{

--- a/galasa-ui/src/tests/components/PageHeader.test.tsx
+++ b/galasa-ui/src/tests/components/PageHeader.test.tsx
@@ -21,6 +21,10 @@ jest.mock('next/navigation', () => ({
   useRouter: jest.fn(() => mockRouter),
 
 }));
+jest.mock('@/utils/locale', () => ({
+  setUserLocale: jest.fn(), // mock the function
+}));
+
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {

--- a/galasa-ui/src/tests/components/PageHeaderMenu.test.tsx
+++ b/galasa-ui/src/tests/components/PageHeaderMenu.test.tsx
@@ -17,6 +17,10 @@ const mockRouter = {
   refresh: jest.fn(() => useRouter().refresh)
 };
 
+jest.mock('@/utils/locale', () => ({
+  setUserLocale: jest.fn(), // mock the function
+}));
+
 jest.mock('next/navigation', () => ({
 
   useRouter: jest.fn(() => mockRouter),

--- a/galasa-ui/src/tests/components/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunsTable.test.tsx
@@ -24,6 +24,7 @@ jest.mock("next-intl", () => ({
     const translations: Record<string, string> = {
       "timeFrameText.range": "Showing test runs submitted between Jan 1 and Jan 10",
       "pagination.forwardText": "Next page",
+      "noTestRunsFound":"No test runs were found for the selected timeframe"
     };
 
     let text = translations[key] || key;
@@ -109,7 +110,7 @@ describe('TestRunsTable Component', () => {
     render(<TestRunsTable runsListPromise={runsPromise} />);
 
     // Assert: Check if the error state is displayed
-    expect(await screen.findByText(/No test runs were found/i)).toBeInTheDocument();
+    expect(await screen.findByText(/No test runs were found for the selected timeframe/i)).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
   });
 

--- a/galasa-ui/src/tests/index.test.tsx
+++ b/galasa-ui/src/tests/index.test.tsx
@@ -6,17 +6,9 @@
 import HomePage from '@/app/page';
 import PageHeader from '@/components/headers/PageHeader';
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagContext';
+import { getMarkdownFilePath } from '@/utils/markdown';
 import { act, render, screen } from '@testing-library/react';
-
-jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
-    const mockTranslations: Record<string, string> = {
-      "title": "Home",
-     
-    };
-    return mockTranslations[key] || key;
-  }
-}));
+import fs, { PathLike } from 'fs';
 
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => {
@@ -32,9 +24,10 @@ jest.mock('fs/promises', () => ({
   readFile: jest.fn(() => Promise.resolve('Dummy markdown content'))
 }));
 
-jest.mock('path', () => ({
-  join: jest.fn(() => '/mocked/path/to/home-contents.md')
+jest.mock("path", () => ({
+  join: jest.fn((...args: string[]) => args.join("/")),
 }));
+
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: jest.fn(),
@@ -45,7 +38,6 @@ jest.mock('next/navigation', () => ({
     prefetch: jest.fn(),
   }),
 }));
-
 
 test('renders Galasa header', () => {
   render(
@@ -60,10 +52,27 @@ test('renders Galasa header', () => {
 
 test('renders Galasa Ecosystem homepage', async () => {
   const homePage = await act(async () => {
+    const homePageComponent = await HomePage();
     return render(
       <FeatureFlagProvider>
-        <HomePage />
+        {homePageComponent}
       </FeatureFlagProvider>);
   });
   expect(homePage).toMatchSnapshot();
+});
+
+test('getMarkdownFilePath returns localized path when that file exists', () => {
+  (fs.existsSync as jest.Mock) = jest.fn((filepath: PathLike) =>
+    typeof filepath === 'string' && filepath.includes('home-contents.de.md')
+  );
+
+  const result = getMarkdownFilePath('de');
+  expect(result).toContain('home-contents.de.md');
+});
+
+test('getMarkdownFilePath returns fallback path when localized does not exist', () => {
+  (fs.existsSync as jest.Mock) = jest.fn().mockReturnValue(false);
+
+  const result = getMarkdownFilePath('fr');
+  expect(result).toContain('home-contents.md');
 });

--- a/galasa-ui/src/tests/index.test.tsx
+++ b/galasa-ui/src/tests/index.test.tsx
@@ -18,7 +18,10 @@ jest.mock('next-intl', () => ({
     return translations[key] || key;
   }
 }));
-
+jest.mock('next-intl/server', () => ({
+  getLocale: jest.fn(() => Promise.resolve('en')),
+  getMessages: jest.fn(() => Promise.resolve({})),
+}));
 
 jest.mock('fs/promises', () => ({
   readFile: jest.fn(() => Promise.resolve('Dummy markdown content'))
@@ -37,6 +40,12 @@ jest.mock('next/navigation', () => ({
     forward: jest.fn(),
     prefetch: jest.fn(),
   }),
+}));
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+  })),
 }));
 
 test('renders Galasa header', () => {

--- a/galasa-ui/src/tests/layout.test.tsx
+++ b/galasa-ui/src/tests/layout.test.tsx
@@ -27,6 +27,9 @@ jest.mock('next/headers', () => ({
   }),
 }));
 
+jest.mock('@/utils/locale', () => ({
+  setUserLocale: jest.fn(), // mock the function
+}));
 
 jest.mock('next-intl/server', () => ({
   getLocale: jest.fn(() => Promise.resolve('en')), // ✅ mock getLocale async

--- a/galasa-ui/src/utils/markdown.ts
+++ b/galasa-ui/src/utils/markdown.ts
@@ -1,0 +1,12 @@
+// src/utils/markdown.ts
+import fs from "fs";
+import path from "path";
+
+export function getMarkdownFilePath(locale: string): string {
+  const localizedFileName = `home-contents.${locale}.md`;
+  const fallbackFileName = `home-contents.md`;
+  const markdownDir = path.join(process.cwd(), "public", "static", "markdown");
+  const localizedFilePath = path.join(markdownDir, localizedFileName);
+  const fallbackFilePath = path.join(markdownDir, fallbackFileName);
+  return fs.existsSync(localizedFilePath) ? localizedFilePath : fallbackFilePath;
+}

--- a/galasa-ui/src/utils/markdown.ts
+++ b/galasa-ui/src/utils/markdown.ts
@@ -1,4 +1,9 @@
-// src/utils/markdown.ts
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
 import fs from "fs";
 import path from "path";
 


### PR DESCRIPTION
- Removed unnecessary Carbon icon from UI
- Loaded localized markdown file for DE locale
- Fixed layout issues caused by longer German translations
- Ensured fallback to English when feature flag is off
- Corrected pluralization and label mismatches ("Benutzeren" → "Benutzer", etc.)
- Applied proper translations in pagination controls via message catalog
- Fixed MISSING_MESSAGE error on Test Run row click
- Corrected "Access Denied" header mistakenly shown on Test Runs page