### PR TITLE
Fix client-side exception and re-rendering bug when setting the locale back to en by default

### DIFF
--- a/galasa-ui/src/app/layout.tsx
+++ b/galasa-ui/src/app/layout.tsx
@@ -5,7 +5,7 @@
  */
 
 import { getClientApiVersion, getServiceHealthStatus } from '@/utils/health';
-import {NextIntlClientProvider, hasLocale} from 'next-intl';
+import { NextIntlClientProvider } from 'next-intl';
 import Footer from '@/components/Footer';
 import PageHeader from '@/components/headers/PageHeader';
 import '@/styles/global.scss';

--- a/galasa-ui/src/app/layout.tsx
+++ b/galasa-ui/src/app/layout.tsx
@@ -19,7 +19,6 @@ export const dynamic = "force-dynamic";
 export default async function RootLayout({children,}: {children: React.ReactNode}) {
   // Ensure that the incoming `locale` is valid
   const locale = await getLocale();
-
  
   const galasaServiceName = process.env.GALASA_SERVICE_NAME?.trim() || "Galasa Service";
   const featureFlagsCookie = cookies().get(FeatureFlagCookies.FEATURE_FLAGS)?.value;

--- a/galasa-ui/src/components/headers/PageHeaderMenu.tsx
+++ b/galasa-ui/src/components/headers/PageHeaderMenu.tsx
@@ -5,7 +5,7 @@
  */
 'use client';
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import { HeaderGlobalBar, OverflowMenu, OverflowMenuItem, HeaderName } from '@carbon/react';
 import { User } from "@carbon/icons-react";
 import { useRouter } from 'next/navigation';
@@ -29,14 +29,19 @@ function PageHeaderMenu({ galasaServiceName }: { galasaServiceName: string }) {
     router.push("/mysettings");
   };
   const {isFeatureEnabled} = useFeatureFlags();
+
+  const isInternationalizationEnabled = isFeatureEnabled(FEATURE_FLAGS.INTERNATIONALIZATION);
   
-  if(!isFeatureEnabled(FEATURE_FLAGS.INTERNATIONALIZATION)) {
-    setUserLocale("en");
-  }
+  useEffect(() => {
+    if (!isInternationalizationEnabled) {
+      setUserLocale("en");
+    }
+  }, [isInternationalizationEnabled]);
+
   return (
     <HeaderGlobalBar data-testid="header-menu">
 
-      {isFeatureEnabled(FEATURE_FLAGS.INTERNATIONALIZATION) && ( <LanguageSelector/>)}
+      {isInternationalizationEnabled && (<LanguageSelector/>)}
       <HeaderName prefix="">{galasaServiceName}</HeaderName>
       <OverflowMenu
         data-floating-menu-container

--- a/galasa-ui/src/utils/locale.ts
+++ b/galasa-ui/src/utils/locale.ts
@@ -5,17 +5,13 @@
  */
 "use server";
 
-import {cookies} from 'next/headers';
-import {Locale, defaultLocale} from '@/i18n/config';
+import { cookies } from 'next/headers';
+import { Locale } from '@/i18n/config';
 
 // In this example the locale is read from a cookie. You could alternatively
 // also read it from a database, backend service, or any other source.
 const COOKIE_NAME = 'NEXT_LOCALE';
 
-export async function getUserLocale() {
-  return (await cookies()).get(COOKIE_NAME)?.value || defaultLocale;
-}
-
 export async function setUserLocale(locale: Locale) {
-  (await cookies()).set(COOKIE_NAME, locale);
+  cookies().set(COOKIE_NAME, locale);
 }


### PR DESCRIPTION
## Why
Related to changes in https://github.com/galasa-dev/webui/pull/124

Fixes the following client-side error that is being thrown as the webui tries to constantly set the locale back to "en" if the internationalization feature flag is disabled:
```
 ⨯ Error: Server Functions cannot be called during initial render. This would create a fetch waterfall. Try to use a Server Component to pass data to Client Components instead.
    at PageHeaderMenu (./src/components/headers/PageHeaderMenu.tsx:44:69)
digest: "3803599244"
 GET / 500 in 109ms
```