### PR TITLE
fix(results table): correct pagination text in test runs table

### DIFF
--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -255,7 +255,7 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
           forwardText={translations("pagination.forwardText")}
           itemsPerPageText={translations("pagination.itemsPerPageText")}
           itemRangeText={(min:number, max:number, total:number) =>`${min}–${max} ${translations("pagination.of")} ${total} ${translations("pagination.items")}`}
-          pageRangeText={(total:number) =>`${translations("pagination.of")} ${total} ${translations("pagination.pages")}`}
+          pageRangeText={(current:number, total:number) =>`${translations("pagination.of")} ${total} ${translations("pagination.pages")}`}
           pageNumberText={translations("pagination.pageNumberText")}
           page={currentPage}
           pageSize={pageSize}

--- a/galasa-ui/src/tests/components/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunsTable.test.tsx
@@ -8,7 +8,7 @@ import '@testing-library/jest-dom';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import TestRunsTable from '@/components/test-runs/TestRunsTable';
-import { TestRunsData } from '@/app/test-runs/page';
+import { TestRunsData } from '@/utils/testRuns';
 import { MAX_RECORDS } from '@/utils/constants/common';
 
 // Mock the useRouter hook from Next.js to return a mock router object.
@@ -24,7 +24,8 @@ jest.mock("next-intl", () => ({
     const translations: Record<string, string> = {
       "timeFrameText.range": "Showing test runs submitted between Jan 1 and Jan 10",
       "pagination.forwardText": "Next page",
-      "noTestRunsFound":"No test runs were found for the selected timeframe"
+      "noTestRunsFound":"No test runs were found for the selected timeframe",
+      "pagination.of": "of {total}"
     };
 
     let text = translations[key] || key;
@@ -38,9 +39,6 @@ jest.mock("next-intl", () => ({
     return text;
   },
 }));
-
-
-
 
 jest.mock('@/app/error/page', () =>
   function MockErrorPage() {
@@ -157,6 +155,8 @@ describe('TestRunsTable Interactions', () => {
     
     // Assert initial state
     expect(within(table).getAllByRole('row')).toHaveLength(11); // 1 header + 10 data
+    // Assert correct page range text
+    expect(screen.getByText(/of 2/i)).toBeInTheDocument();
     expect(screen.queryByText('Test Run 11')).not.toBeInTheDocument();
 
     // Act


### PR DESCRIPTION
## Why?
Fixes [galasa-dev/projectmanagement#2306](https://github.com/galasa-dev/projectmanagement/issues/2306)