### PR TITLE
OverviewTab now displays package name

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -182,6 +182,7 @@
   "OverviewTab": {
     "bundle": "Bundle",
     "test": "Test",
+    "package": "Paket",
     "group": "Gruppe",
     "submissionId": "Übermittlungs-ID",
     "requestor": "Anforderer",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -182,6 +182,7 @@
   "OverviewTab": {
     "bundle": "Bundle",
     "test": "Test",
+    "package": "Package",
     "group": "Group",
     "submissionId": "Submission ID",
     "requestor": "Requestor",

--- a/galasa-ui/src/components/test-runs/LogTab.tsx
+++ b/galasa-ui/src/components/test-runs/LogTab.tsx
@@ -13,9 +13,9 @@ import {
   Filter,
   ChevronUp,
   ChevronDown,
-  CharacterSentenceCase,
-  TextUnderline,
   CloudDownload,
+  Term,
+  LetterAa,
 } from "@carbon/icons-react";
 import { handleDownload } from "@/utils/artifacts";
 import { useTranslations } from "next-intl";
@@ -448,7 +448,7 @@ export default function LogTab({ logs }: { logs: string }) {
                 kind={matchCase ? "primary" : "ghost"}
                 size="sm"
                 onClick={toggleMatchCase}
-                renderIcon={CharacterSentenceCase}
+                renderIcon={LetterAa}
                 iconDescription={translations("match_case")}
                 hasIconOnly
               />
@@ -456,7 +456,7 @@ export default function LogTab({ logs }: { logs: string }) {
                 kind={matchWholeWord ? "primary" : "ghost"}
                 size="sm"
                 onClick={toggleMatchWholeWord}
-                renderIcon={TextUnderline}
+                renderIcon={Term}
                 iconDescription={translations("match_whole_word")}
                 hasIconOnly
               />

--- a/galasa-ui/src/components/test-runs/OverviewTab.tsx
+++ b/galasa-ui/src/components/test-runs/OverviewTab.tsx
@@ -49,6 +49,10 @@ const OverviewTab = ({ metadata }: { metadata: RunMetadata }) => {
         title={`${translations("test")}:`}
         value={metadata?.testName}
       />
+      <InlineText
+        title={`${translations("package")}:`}
+        value={metadata?.package}
+      />
       <InlineText title={`${translations("group")}:`} value={metadata?.group} />
       <InlineText
         title={`${translations("submissionId")}:`}

--- a/galasa-ui/src/tests/components/OverviewTab.test.tsx
+++ b/galasa-ui/src/tests/components/OverviewTab.test.tsx
@@ -34,6 +34,7 @@ jest.mock("next-intl", () => ({
     const translations: Record<string, string> = {
       bundle: "Bundle",
       test: "Test",
+      package: "Package",
       group: "Group",
       submissionId: "Submission ID",
       requestor: "Requestor",
@@ -77,6 +78,7 @@ describe('OverviewTab', () => {
     [
       ['Bundle:', completeMetadata.bundle],
       ['Test:', completeMetadata.testName],
+      ['Package:', completeMetadata.package],
       ['Group:', completeMetadata.group],
       ['Submission ID:', completeMetadata.submissionId],
       ['Requestor:', completeMetadata.requestor],


### PR DESCRIPTION
# Why?

- Refer to https://github.com/galasa-dev/projectmanagement/issues/2300
- REST API will have to support returning a stream name while fetching test run details, so omitted in this story. Will craft a new story for that.

Signed-off-by: Aashir Siddiqui <aashir_sidiki@hotmail.com>
