### PR TITLE
Persisting search queries during Test Runs navigation

### DIFF
--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -22,7 +22,6 @@ import { HOME, TEST_RUNS } from '@/utils/constants/breadcrumb';
 import TestRunSkeleton from './TestRunSkeleton';
 import { useTranslations } from 'next-intl';
 import StatusIndicator from '../common/StatusIndicator';
-import { useRouter, useSearchParams } from 'next/navigation';
 
 interface TestRunDetailsProps {
   runId: string;
@@ -33,8 +32,6 @@ interface TestRunDetailsProps {
 
 // Type the props directly on the function's parameter
 const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsPromise }: TestRunDetailsProps) => {
-  const searchParams = useSearchParams();
-  const router = useRouter();
   const translations = useTranslations("TestRunDetails");
 
   const [run, setRun] = useState<RunMetadata>();

--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -48,9 +48,6 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
       const storedQuery = sessionStorage.getItem('testRunsQuery');
       if (storedQuery) {
         setSavedQuery(storedQuery);
-
-        // Clean up the sessionStorage
-        sessionStorage.removeItem('testRunsQuery');
       }
     }
   }, []);

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -196,7 +196,7 @@ export default function TestRunsTable({runsListPromise, visibleColumns, orderedH
   const handleRowClick = (runId: string) => {
     const queryString = searchParams.toString();
 
-    // Save the query string to the sessionStorage
+    // Save the query string to the sessionStorage if the window object is available
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('testRunsQuery', queryString);
     }

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -29,12 +29,13 @@ import { TableHeadProps } from "@carbon/react/lib/components/DataTable/TableHead
 import { TableBodyProps } from "@carbon/react/lib/components/DataTable/TableBody";
 import StatusIndicator from "../common/StatusIndicator";
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import ErrorPage from "@/app/error/page";
 import { TestRunsData } from "@/utils/testRuns";
-import {MAX_RECORDS} from "@/utils/constants/common";
+import { MAX_RECORDS} from "@/utils/constants/common";
 import { useTranslations } from "next-intl";
 import { InlineNotification } from "@carbon/react";
+import { run } from "node:test";
 
 
 
@@ -93,6 +94,8 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
   const translations = useTranslations("TestRunsTable");
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [rawRuns, setRawRuns] = useState<Run[]>([]);
@@ -196,7 +199,15 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
 
   // Navigate to the test run details page using the runId
   const handleRowClick = (runId: string) => {
-    router.push(`/test-runs/${runId}`);
+    const queryString = searchParams.toString();
+
+    // Save the query string to the sessionStorage
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('testRunsQuery', queryString);
+    }
+
+    // Navigate to the test run details page
+    router.push(`/test-runs/${runId}`)
   };
 
   if ( !tableRows || tableRows.length === 0) {

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -35,7 +35,7 @@ import { TestRunsData } from "@/utils/testRuns";
 import { MAX_RECORDS} from "@/utils/constants/common";
 import { useTranslations } from "next-intl";
 import { InlineNotification } from "@carbon/react";
-import { run } from "node:test";
+
 
 interface CustomCellProps {
   header: string;

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -207,7 +207,7 @@ export default function TestRunsTable({runsListPromise}: {runsListPromise: Promi
     }
 
     // Navigate to the test run details page
-    router.push(`/test-runs/${runId}`)
+    router.push(`/test-runs/${runId}`);
   };
 
   if ( !tableRows || tableRows.length === 0) {

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import TestRunDetails from '@/components/test-runs/TestRunDetails';
+import { get } from 'http';
 
 
 function setup<T>() {
@@ -18,6 +19,30 @@ function setup<T>() {
   return { promise, resolve, reject };
 }
 
+// Mock sessionStorage
+const sessonStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    setItem(key: string, value: string) {
+      store[key] = value;
+    },
+    getItem(key: string) {
+      return store[key] || null;
+    }, 
+    removeItem(key: string) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', {
+  value: sessonStorageMock,
+  writable: true,
+});
+
 // Mocking next-intl
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string, opts?: any) =>
@@ -25,7 +50,16 @@ jest.mock('next-intl', () => ({
 }));
 
 jest.mock('@/components/common/BreadCrumb', () => {
-  const BreadCrumb = () => <nav>Breadcrumb</nav>;
+  const BreadCrumb = ({ breadCrumbItems }: { breadCrumbItems: any[] }) => {
+    const testRunsItem = breadCrumbItems.find(
+      (item) => item.title === 'testRuns'
+    );
+    return (
+      <nav data-testid="breadcrumb" data-route={testRunsItem?.route || ''}>
+        Breadcrumb
+      </nav>
+    );
+  };
   BreadCrumb.displayName = 'BreadCrumb';
   return {
     __esModule: true,
@@ -139,6 +173,10 @@ jest.mock('@carbon/react', () => {
 describe('TestRunDetails', () => {
   const runId = 'run-123';
 
+  beforeEach(() => {
+    sessonStorageMock.clear();
+  });
+
   it('shows the skeleton while loading', async () => {
     const runDetailsDeferred = setup<any>();
     const runArtifactsDeferred = setup<any[]>();
@@ -250,4 +288,62 @@ describe('TestRunDetails', () => {
 
     expect(await screen.findByText('ErrorPage')).toBeInTheDocument();
   });
+
+  it('build savedQuery from the sessionStorage and clears it', async () => {
+    const runDetailsDeferred = setup<any>();
+    const runArtifactsDeferred = setup<any[]>();
+    const runLogDeferred = setup<string>();
+
+    // Set a query string in sessionStorage
+    const queryString = 'status=Finished&result=Success';
+    sessionStorage.setItem('testRunsQuery', queryString);
+
+    // Verify it is set correctly
+    expect(sessionStorage.getItem('testRunsQuery')).toBe(queryString);
+
+    render(
+      <TestRunDetails
+        runId={runId}
+        runDetailsPromise={runDetailsDeferred.promise}
+        runArtifactsPromise={runArtifactsDeferred.promise}
+        runLogPromise={runLogDeferred.promise}
+      />
+    );
+
+    // Check the breadcrumb props
+    const breadcrumb = screen.getByTestId('breadcrumb');
+
+    // Check if the link is correc
+    expect(breadcrumb).toHaveAttribute('data-route', `/test-runs?${queryString}`);
+
+    // Check that the sessionStorage was cleaned up after being read
+    expect(sessionStorage.getItem('testRunsQuery')).toBeNull();
+
+    // Resolve the promises to ensure the component loads correctly
+    await act(async () => {
+      runDetailsDeferred.resolve({
+        testStructure: {
+          methods: [],
+          result: 'PASS',
+          status: 'OK',
+          runName: 'r1',
+          testShortName: 't1',
+          bundle: 'b1',
+          submissionId: 's1',
+          group: 'g1',
+          requestor: 'u1',
+          queued: '2025-01-01T00:00:00Z',
+          startTime: '2025-01-01T00:00:00Z',
+          endTime: '2025-01-01T01:00:00Z',
+          tags: [],
+        },
+      });
+      runArtifactsDeferred.resolve([]);
+      runLogDeferred.resolve('');
+    });
+
+    // Final check to ensure breadcrumb still has the correct route after loading
+    expect(breadcrumb).toHaveAttribute('data-route', `/test-runs?${queryString}`);
+  });
+
 });

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -29,9 +29,6 @@ const sessonStorageMock = (() => {
     getItem(key: string) {
       return store[key] || null;
     }, 
-    removeItem(key: string) {
-      delete store[key];
-    },
     clear() {
       store = {};
     },
@@ -315,9 +312,6 @@ describe('TestRunDetails', () => {
 
     // Check if the link is correc
     expect(breadcrumb).toHaveAttribute('data-route', `/test-runs?${queryString}`);
-
-    // Check that the sessionStorage was cleaned up after being read
-    expect(sessionStorage.getItem('testRunsQuery')).toBeNull();
 
     // Resolve the promises to ensure the component loads correctly
     await act(async () => {

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -6,8 +6,6 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import TestRunDetails from '@/components/test-runs/TestRunDetails';
-import { get } from 'http';
-
 
 function setup<T>() {
   let resolve!: (value: T) => void;

--- a/galasa-ui/src/tests/components/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunsTable.test.tsx
@@ -10,6 +10,7 @@ import { fireEvent } from '@testing-library/react';
 import TestRunsTable from '@/components/test-runs/TestRunsTable';
 import { TestRunsData } from '@/utils/testRuns';
 import { MAX_RECORDS } from '@/utils/constants/common';
+import { useSearchParams } from 'next/navigation';
 
 // Mock the useRouter hook from Next.js to return a mock router object.
 const mockRouterPush = jest.fn();
@@ -17,6 +18,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: mockRouterPush,
   }),
+  useSearchParams: () => new URLSearchParams(),
 }));
 
 jest.mock("next-intl", () => ({


### PR DESCRIPTION
## Why?
Closes [galasa-dev/projectmanagement#2275](https://github.com/galasa-dev/projectmanagement/issues/2275)
## Changes 
- The search query is now stored in `sessionStorage` before redirecting to the Test Run Page.
- The Single Test Run page retrieves the last saved query from `sessionStorage` (stored in state).
- Added unit test to verify the functionality.
   
> [!NOTE]
> Why `sessionStorage` instead of URL parameters? 
> Passing the query via URL is intentionally avoided to maintain a clean URL structure for the Single Test Run page. This ensures the URL remains available for test-run-specific qualifiers without cluttering it with unnecessary search parameters.