### PR TITLE
Fix: Dark mode visual inconsistencies across Test Runs and Single Test Run pages

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -151,7 +151,7 @@
     "title": "Artefakte",
     "description": "Ein Artefakt ist ein Zustand, der nach einem Lauf erhalten bleibt. Artefakte können heruntergeladen und angezeigt werden.",
     "downloading": "Artefakt wird heruntergeladen",
-    "download_button": "Herunterladen",
+    "download_button": "Dieses Artefakt herunterladen",
     "error_title": "Fehler",
     "error_subtitle": "Fehler beim Herunterladen. Versuchen Sie es erneut oder verwenden Sie das CLI-Tool:\ngalasactl runs download --name {runName}",
     "select_file": "Datei auswählen, um Inhalt anzuzeigen",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -151,7 +151,7 @@
     "title": "Artifacts",
     "description": "An artifact is a piece of captured state left behind once a Run has completed. Artifacts can also be downloaded and viewed.",
     "downloading": "Downloading Artifact",
-    "download_button": "Download",
+    "download_button": "Download this artifact",
     "error_title": "Something went wrong",
     "error_subtitle": "There was an error downloading the artifact. It may be that the artifact is too big for this web application, try refreshing the page or downloading the test run using the 'galasactl' command-line tool.\nFor example:\ngalasactl runs download --name {runName}",
     "select_file": "Select a file to display its content",

--- a/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
@@ -14,7 +14,6 @@ import { downloadArtifactFromServer } from '@/actions/runsAction';
 import { Tile } from '@carbon/react';
 import { handleDownload } from '@/utils/artifacts';
 import { useTranslations } from 'next-intl';
-import { Tooltip } from '@carbon/react';
 import { Button } from '@carbon/react';
 
 interface FileNode {

--- a/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
@@ -15,6 +15,7 @@ import { Tile } from '@carbon/react';
 import { handleDownload } from '@/utils/artifacts';
 import { useTranslations } from 'next-intl';
 import { Tooltip } from '@carbon/react';
+import { Button } from '@carbon/react';
 
 interface FileNode {
   name: string;
@@ -338,16 +339,14 @@ export function ArtifactsTab({ artifacts, runId, runName }: { artifacts: Artifac
                       </p>
                     </div>
                     <div className={styles.toolbarOptions}>
-                      <Tooltip label={translations("download_button")} align="bottom">
-                        <button
-                          type="button"
-                          onClick={handleDownloadClick}
-                          role='download-button'
-                          className={styles.downloadButton}
-                        >
-                          <CloudDownload size={22} className={styles.clouddownload} />
-                        </button>
-                      </Tooltip>
+                      <Button
+                        kind="ghost"
+                        renderIcon={CloudDownload}
+                        hasIconOnly
+                        iconDescription={translations("download_button")}
+                        onClick={handleDownloadClick}
+                        />
+            
                     </div>
                   </Tile>
                 )}

--- a/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
@@ -14,6 +14,7 @@ import { downloadArtifactFromServer } from '@/actions/runsAction';
 import { Tile } from '@carbon/react';
 import { handleDownload } from '@/utils/artifacts';
 import { useTranslations } from 'next-intl';
+import { Tooltip } from '@carbon/react';
 
 interface FileNode {
   name: string;
@@ -337,14 +338,16 @@ export function ArtifactsTab({ artifacts, runId, runName }: { artifacts: Artifac
                       </p>
                     </div>
                     <div className={styles.toolbarOptions}>
-                      <button
-                        type="button"
-                        onClick={handleDownloadClick}
-                        role='download-button'
-                        className={styles.downloadButton}
-                      >
-                        <CloudDownload size={22} className={styles.clouddownload} />
-                      </button>
+                      <Tooltip label={translations("download_button")} align="bottom">
+                        <button
+                          type="button"
+                          onClick={handleDownloadClick}
+                          role='download-button'
+                          className={styles.downloadButton}
+                        >
+                          <CloudDownload size={22} className={styles.clouddownload} />
+                        </button>
+                      </Tooltip>
                     </div>
                   </Tile>
                 )}

--- a/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
@@ -345,7 +345,7 @@ export function ArtifactsTab({ artifacts, runId, runName }: { artifacts: Artifac
                         hasIconOnly
                         iconDescription={translations("download_button")}
                         onClick={handleDownloadClick}
-                        />
+                      />
             
                     </div>
                   </Tile>

--- a/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/ArtifactsTab.tsx
@@ -343,7 +343,7 @@ export function ArtifactsTab({ artifacts, runId, runName }: { artifacts: Artifac
                         role='download-button'
                         className={styles.downloadButton}
                       >
-                        <CloudDownload size={22} color="#0043ce" />
+                        <CloudDownload size={22} className={styles.clouddownload} />
                       </button>
                     </div>
                   </Tile>

--- a/galasa-ui/src/styles/Artifacts.module.css
+++ b/galasa-ui/src/styles/Artifacts.module.css
@@ -51,6 +51,3 @@
   border: none;
   background-color: transparent;
 }
-.clouddownload{
-  color: var(--cds-text-primary);
-}

--- a/galasa-ui/src/styles/Artifacts.module.css
+++ b/galasa-ui/src/styles/Artifacts.module.css
@@ -51,3 +51,6 @@
   border: none;
   background-color: transparent;
 }
+.clouddownload{
+  color: var(--cds-text-primary);
+}

--- a/galasa-ui/src/styles/Selector.module.css
+++ b/galasa-ui/src/styles/Selector.module.css
@@ -32,12 +32,11 @@
 .iconButton {
   background:#262626;
   border: none;
-  padding: 0.5rem;
+  padding: 0.85rem;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 0.25rem;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
@@ -52,7 +51,4 @@
 
 .active {
   color: var(--cds-icon-on-color);
-}
-.themeContainer {
-  border-radius: 0.35rem;
 }

--- a/galasa-ui/src/styles/Selector.module.css
+++ b/galasa-ui/src/styles/Selector.module.css
@@ -30,7 +30,7 @@
 }
 
 .iconButton {
-  background: none;
+  background:#262626;
   border: none;
   padding: 0.5rem;
   cursor: pointer;
@@ -51,7 +51,6 @@
 }
 
 .active {
-  background-color: #474747;
   color: var(--cds-icon-on-color);
 }
 .themeContainer {

--- a/galasa-ui/src/styles/TestRunSkeleton.module.css
+++ b/galasa-ui/src/styles/TestRunSkeleton.module.css
@@ -32,7 +32,6 @@
 }
 
 .logContainer {
-  background-color: #f4f4f4;
   padding: 12px;
   height: 250px;
 }

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -86,7 +86,7 @@
   top: 100%; 
   left: 0;
   right: 0;
-  background-color: white;
+  background-color: var(--cds-background,#161616);
   border: 1px solid #ccc;
   border-top: none;
   list-style-type: none;
@@ -104,12 +104,12 @@
 }
 
 .suggestionList li:hover {
-  background-color: #f0f0f0;
+  background-color:  rgba(136, 136, 136, 0.2);
 }
 
 
 .activeSuggestion {
-  background-color: #e0e0e0; 
+  background-color: var(--cds-background,rgba(136, 136, 136, 0.2)); 
   cursor: pointer;
 }
 
@@ -192,7 +192,6 @@
   border-radius: 0;
   width: 55%;
   min-width: 400px;
-  overflow-x: auto; 
 }
 
 .tableDesignRow,
@@ -265,7 +264,9 @@
 
 .dragHandle {
   cursor: grab;
+
 }
+
 
 .tableDesignRow.dragging .dragHandle {
   cursor: grabbing;

--- a/galasa-ui/src/tests/components/ArtifactsTab.test.tsx
+++ b/galasa-ui/src/tests/components/ArtifactsTab.test.tsx
@@ -65,6 +65,15 @@ jest.mock('@carbon/react', () => ({
       {children}
     </div>
   ),
+  Button: ({ onClick, iconDescription, renderIcon: Icon }: any) => (
+    <button
+      data-testid="mock-carbon-button"
+      aria-label={iconDescription}
+      onClick={onClick}
+    >
+      {Icon && <Icon />}
+    </button>
+  ),
 }));
 
 // Mock Carbon icons
@@ -404,7 +413,7 @@ describe('ArtifactsTab', () => {
         expect(screen.getByTestId('cloud-download-icon')).toBeInTheDocument();
       });
 
-      const downloadButton = screen.getByRole('download-button');
+      const downloadButton = screen.getByRole("button", { name: /download/i });
       
       await act(async () => {
         fireEvent.click(downloadButton);

--- a/galasa-ui/src/tests/components/ArtifactsTab.test.tsx
+++ b/galasa-ui/src/tests/components/ArtifactsTab.test.tsx
@@ -26,6 +26,12 @@ jest.mock('@carbon/react', () => ({
       {children}
     </div>
   ),
+  Tooltip: ({ label, children }: any) => (
+    <div data-testid="tooltip">
+      {label}
+      {children}
+    </div>
+  ),
   TreeNode: ({ children, label, onSelect, onToggle, isExpanded, renderIcon }: any) => {
     const IconComponent = renderIcon;
     return (


### PR DESCRIPTION
### Description:

This PR resolves multiple UI inconsistencies in dark mode:

Closes galasa-dev/projectmanagement#2323
Closes galasa-dev/projectmanagement#2283

- **Table Design Tab**: Fixed tooltip stacking issue for drag-and-drop icon.
- **Search Criteria Tab**: Corrected white background in Requestor dropdown.
- **Artifacts Tab**: Updated download icon color .

### Changes:
- Adjusted  `overflow`, properties for tooltip visibility.
- Made cahnges in CSS for consistent dark mode styling.



