### PR TITLE
Add Share Button Functionality with Clipboard Copy

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -205,6 +205,8 @@
   "TestRunDetails": {
     "title": "Testlauf: {runName}",
     "status": "Status",
+    "copymessage": "Seiten-URL kopieren",
+    "copiedmessage": "Kopiert",
     "result": "Ergebnis",
     "test": "Test",
     "tabs": {

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -204,6 +204,8 @@
   },
   "TestRunDetails": {
     "title": "Test Run: {runName}",
+    "copymessage":"Copy page URL",
+    "copiedmessage":"Copied",
     "status": "Status",
     "result": "Result",
     "test": "Test",

--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -138,7 +138,7 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
               className={styles.shareButton}
               data-testid="icon-Share"
             >
-                <Share size={20}/>
+              <Share size={20}/>
             </button>
           </Tooltip>
         </div>

--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -9,7 +9,7 @@ import PageTile from '@/components/PageTile';
 import { Tab, Tabs, TabList, TabPanels, TabPanel, Loading } from '@carbon/react';
 import React, { useCallback, useEffect, useState } from 'react';
 import styles from "@/styles/TestRun.module.css";
-import { Dashboard, Code, CloudLogging, RepoArtifact } from '@carbon/icons-react';
+import { Dashboard, Code, CloudLogging, RepoArtifact, Share } from '@carbon/icons-react';
 import OverviewTab from './OverviewTab';
 import { ArtifactIndexEntry, Run, TestMethod } from '@/generated/galasaapi';
 import ErrorPage from '@/app/error/page';
@@ -22,6 +22,8 @@ import { HOME, TEST_RUNS } from '@/utils/constants/breadcrumb';
 import TestRunSkeleton from './TestRunSkeleton';
 import { useTranslations } from 'next-intl';
 import StatusIndicator from '../common/StatusIndicator';
+import { Tile } from '@carbon/react';
+import { Tooltip } from '@carbon/react';
 
 interface TestRunDetailsProps {
   runId: string;
@@ -41,6 +43,7 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [savedQuery, setSavedQuery] = useState<string>("");
+  const [copied, setCopied] = useState(false);
 
   // Get the query string from the sessionStorage if it exists
   useEffect(() => {
@@ -112,15 +115,35 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
   const testRunsRoute = savedQuery ? `${TEST_RUNS.route}?${savedQuery}` : TEST_RUNS.route;
   const testRunsBreadCrumb = { ...TEST_RUNS, route: testRunsRoute };
 
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000); 
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
   return (
     <main id="content">
       <BreadCrumb breadCrumbItems={[HOME, testRunsBreadCrumb]} />
-      <PageTile
-        translationKey={translations("title", {
-          runName: run?.runName || "Unknown Run Name",
-        })}
-      />
+      <Tile id="tile" className={styles.toolbar}>
+        {translations("title", { runName: run?.runName || "Unknown Run Name" })}
+        <div className={styles.buttonContainer}>
+          <Tooltip label={copied ? translations('copiedmessage') : translations('copymessage')} align="top">
 
+            <button
+              onClick={handleShare}
+              className={styles.shareButton}
+              data-testid="icon-Share"
+            >
+                <Share size={20}/>
+            </button>
+          </Tooltip>
+        </div>
+      </Tile>
+ 
       {isLoading ? (
         <TestRunSkeleton />
       ) : (

--- a/galasa-ui/src/styles/TestRun.module.css
+++ b/galasa-ui/src/styles/TestRun.module.css
@@ -28,3 +28,22 @@
     gap: 0.5rem;
     text-transform: capitalize;
 }
+
+.toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+.shareButton {
+    background: none;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--cds-text-primary, #161616);
+  }
+.buttonContainer{
+    margin-right: 2rem;
+  }

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import React from 'react';
-import { render, screen, act } from '@testing-library/react';
+import { render, screen, act, fireEvent } from '@testing-library/react';
 import TestRunDetails from '@/components/test-runs/TestRunDetails';
 
 function setup<T>() {

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -154,6 +154,13 @@ jest.mock('@carbon/react', () => {
   const TabPanels = ({ children }: any) => <div>{children}</div>;
   const TabPanel = ({ children }: any) => <div>{children}</div>;
   const Loading = () => <div>Loading</div>;
+  const Tile = ({ children }: any) => <div data-testid="tile">{children}</div>;
+  const Tooltip = ({ label, children }: any) => (
+    <div data-testid="tooltip">
+       {label}
+       {children}
+     </div>
+   );
 
   [Tab, Tabs, TabList, TabPanels, TabPanel, Loading].forEach(c => {
     // @ts-ignore
@@ -161,9 +168,21 @@ jest.mock('@carbon/react', () => {
     // TypeScript does not allow this by default, so we suppress the error.
     c.displayName = c.name || 'Anonymous';
   });
+  Tile.displayName = 'Tile';
+  Tooltip.displayName = 'Tooltip';
 
-  return { Tab, Tabs, TabList, TabPanels, TabPanel, Loading };
+  return { Tab, Tabs, TabList, TabPanels, TabPanel, Loading, Tile, Tooltip, };
 });
+
+
+beforeAll(() => {
+  Object.assign(navigator, {
+    clipboard: {
+      writeText: jest.fn(),
+    },
+  });
+});
+
 
 describe('TestRunDetails', () => {
   const runId = 'run-123';

--- a/galasa-ui/src/tests/components/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunDetails.test.tsx
@@ -157,10 +157,10 @@ jest.mock('@carbon/react', () => {
   const Tile = ({ children }: any) => <div data-testid="tile">{children}</div>;
   const Tooltip = ({ label, children }: any) => (
     <div data-testid="tooltip">
-       {label}
-       {children}
-     </div>
-   );
+      {label}
+      {children}
+    </div>
+  );
 
   [Tab, Tabs, TabList, TabPanels, TabPanel, Loading].forEach(c => {
     // @ts-ignore
@@ -356,5 +356,32 @@ describe('TestRunDetails', () => {
     // Final check to ensure breadcrumb still has the correct route after loading
     expect(breadcrumb).toHaveAttribute('data-route', `/test-runs?${queryString}`);
   });
+  it('copies the URL when share button is clicked', async () => {
+    const runDetailsDeferred = setup<any>();
+    const runArtifactsDeferred = setup<any[]>();
+    const runLogDeferred = setup<string>();
+
+    render(
+      <TestRunDetails
+        runId="run-123"
+        runDetailsPromise={runDetailsDeferred.promise}
+        runArtifactsPromise={runArtifactsDeferred.promise}
+        runLogPromise={runLogDeferred.promise}
+      />
+    );
+  
+    await act(async () => {
+      runDetailsDeferred.resolve({ testStructure: { methods: [], result: 'PASS', status: 'OK', runName: 'X', testShortName: 't', bundle: '', submissionId: '', group: '', requestor: '', queued: '', startTime: '', endTime: '', tags: [] } });
+      runArtifactsDeferred.resolve([]);
+      runLogDeferred.resolve('');
+    });
+  
+    const spy = jest.spyOn(navigator.clipboard, 'writeText');
+    fireEvent.click(screen.getByTestId('icon-Share'));
+  
+    expect(spy).toHaveBeenCalledWith(window.location.href);
+    spy.mockRestore();
+  });
+  
 
 });


### PR DESCRIPTION

##  Closes:
Closes [#2335](https://github.com/galasa-dev/projectmanagement/issues/2330)

---

##  Description:
- Added a share icon button to the Test Run panels.
- Implemented clipboard copy functionality using `navigator.clipboard.writeText`.
- Tooltip included for better user experience on hover.
- Introduced a unit test to verify that clicking the share button copies the current page URL.

demo-

https://github.com/user-attachments/assets/99fcbae4-0959-4d6f-b502-997a095f5f92


