### PR TITLE
Add Multi-Level Sort Support with Shareable URL State

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -376,7 +376,8 @@
     "columnName": "Spaltenname",
     "showHideHeader": "Spalten ein-/ausblenden",
     "warning": "Warnung",
-    "noColumnsSelected": "Keine Spalten ausgewählt – nichts anzuzeigen. Bitte wählen Sie eine oder mehrere Spalten aus"    
+    "noColumnsSelected": "Keine Spalten ausgewählt – nichts anzuzeigen. Bitte wählen Sie eine oder mehrere Spalten aus",
+    "sortOrderHeader": "Sortierreihenfolge"
   },
   "TableDesignRow": {
     "dragAndDropLabel": "Ziehen zum Neuordnen",
@@ -392,6 +393,9 @@
     "tags": "Tags",
     "status": "Status",
     "result": "Ergebnis",
-    "submissionId":"Übermittlungs-ID"
+    "submissionId":"Übermittlungs-ID",
+    "none": "Keine",
+    "asc": "Aufsteigend",
+    "desc": "Absteigend"
   }
 }

--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -384,7 +384,7 @@
     "moveUpLabel": "Nach oben verschieben",
     "moveDownLabel": "Nach unten verschieben",
     "submittedAt": "Eingereicht am",
-    "testRunName": "Name des Testlaufs",
+    "runName": "Name des Testlaufs",
     "requestor": "Anforderer",
     "group": "Gruppe",
     "bundle": "Bundle",

--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -227,7 +227,7 @@
   },
   "TestRunsTable": {
     "submittedAt": "Eingereicht am",
-    "testRunName": "Name des Testlaufs",
+    "runName": "Name des Testlaufs",
     "requestor": "Anforderer",
     "group": "Gruppe",
     "bundle": "Bundle",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -376,7 +376,8 @@
     "columnName": "Column Name",
     "showHideHeader": "Show/Hide Columns",
     "warning": "Warning",
-    "noColumnsSelected": "No columns selected – nothing to display. Please select one or more columns."
+    "noColumnsSelected": "No columns selected – nothing to display. Please select one or more columns.",
+    "sortOrderHeader": "Sort Order"
   }, 
   "TableDesignRow": {
     "dragAndDropLabel": "Drag to reorder",
@@ -392,6 +393,9 @@
     "tags": "Tags",
     "status": "Status",
     "result": "Result",
-    "submissionId": "Submission ID"
+    "submissionId": "Submission ID",
+    "none": "None",
+    "asc": "Ascending",
+    "desc": "Descending"
   }
 }

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -384,7 +384,7 @@
     "moveUpLabel": "Move up",
     "moveDownLabel": "Move down",
     "submittedAt": "Submitted at",
-    "testRunName": "Test Run Name",
+    "runName": "Test Run Name",
     "requestor": "Requestor",
     "group": "Group",
     "bundle": "Bundle",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -227,7 +227,7 @@
   },
   "TestRunsTable": {
     "submittedAt": "Submitted at",
-    "testRunName": "Test Run Name",
+    "runName": "Test Run Name",
     "requestor": "Requestor",
     "group": "Group",
     "bundle": "Bundle",

--- a/galasa-ui/src/components/test-runs/TableDesignContent.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignContent.tsx
@@ -123,7 +123,7 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
         <SortableContext items={tableRows.map(row => row.id)} strategy={verticalListSortingStrategy}>
           {
             tableRows.map((row) => {
-               const currentSort = sortOrder?.find(order => order.id === row.id);
+              const currentSort = sortOrder?.find(order => order.id === row.id);
               return <TableDesignRow 
                 key={row.id} 
                 rowId={row.id} 
@@ -131,7 +131,7 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
                 isSelected={selectedRowIds.includes(row.id)}
                 onSelect={handleRowSelect}
                 onSortOrderChange={handleSortOrderChange}
-              />
+              />;
             }) 
           }
         </SortableContext>

--- a/galasa-ui/src/components/test-runs/TableDesignContent.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignContent.tsx
@@ -11,6 +11,7 @@ import TableDesignRow from "./TableDesignRow";
 import { Checkbox } from "@carbon/react";
 import { useTranslations } from "next-intl";
 import { InlineNotification } from "@carbon/react";
+import { sortOrder } from "@/utils/interfaces";
 
 
 interface TableDesignContentProps {
@@ -18,6 +19,8 @@ interface TableDesignContentProps {
     setSelectedRowIds: React.Dispatch<React.SetStateAction<string[]>>;
     tableRows: { id: string; columnName: string }[];
     setTableRows: React.Dispatch<React.SetStateAction<{ id: string; columnName: string }[]>>;
+    sortOrder?: { id: string; order: sortOrder}[];
+    setSortOrder?: React.Dispatch<React.SetStateAction<{ id: string; order: sortOrder }[]>>;
 }
 
 export default function TableDesignContent({selectedRowIds, setSelectedRowIds, tableRows, setTableRows}: TableDesignContentProps) {
@@ -90,6 +93,9 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
           </div>
           <div className={styles.cellValue}>
             <strong>{translations("columnName")}</strong>
+          </div>
+          <div className={styles.cellDropdownHeader}>
+            <strong>{translations("sortOrderHeader")}</strong>
           </div>
         </div>
         <SortableContext items={tableRows.map(row => row.id)} strategy={verticalListSortingStrategy}>

--- a/galasa-ui/src/components/test-runs/TableDesignContent.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignContent.tsx
@@ -11,14 +11,14 @@ import TableDesignRow from "./TableDesignRow";
 import { Checkbox } from "@carbon/react";
 import { useTranslations } from "next-intl";
 import { InlineNotification } from "@carbon/react";
-import { sortOrderType } from "@/utils/interfaces";
+import { ColumnDefinition, sortOrderType } from "@/utils/interfaces";
 
 
 interface TableDesignContentProps {
     selectedRowIds: string[];
     setSelectedRowIds: React.Dispatch<React.SetStateAction<string[]>>;
-    tableRows: { id: string; columnName: string }[];
-    setTableRows: React.Dispatch<React.SetStateAction<{ id: string; columnName: string }[]>>;
+    tableRows: ColumnDefinition[];
+    setTableRows: React.Dispatch<React.SetStateAction<ColumnDefinition[]>>;
     sortOrder?: { id: string; order: sortOrderType }[];
     setSortOrder?: React.Dispatch<React.SetStateAction<{ id: string; order: sortOrderType }[]>>;
 }
@@ -53,7 +53,7 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
     const { active , over } = event;
 
     if (over && active.id !== over.id) {
-      setTableRows((rows: { id: string; columnName: string }[]) => {
+      setTableRows((rows: ColumnDefinition[]) => {
         const originalPosition = getRowPosition(String(active.id));
         const newPosition = getRowPosition(String(over.id));
         return arrayMove(rows, originalPosition, newPosition);

--- a/galasa-ui/src/components/test-runs/TableDesignContent.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignContent.tsx
@@ -11,7 +11,7 @@ import TableDesignRow from "./TableDesignRow";
 import { Checkbox } from "@carbon/react";
 import { useTranslations } from "next-intl";
 import { InlineNotification } from "@carbon/react";
-import { sortOrder } from "@/utils/interfaces";
+import { sortOrderType } from "@/utils/interfaces";
 
 
 interface TableDesignContentProps {
@@ -19,11 +19,11 @@ interface TableDesignContentProps {
     setSelectedRowIds: React.Dispatch<React.SetStateAction<string[]>>;
     tableRows: { id: string; columnName: string }[];
     setTableRows: React.Dispatch<React.SetStateAction<{ id: string; columnName: string }[]>>;
-    sortOrder?: { id: string; order: sortOrder}[];
-    setSortOrder?: React.Dispatch<React.SetStateAction<{ id: string; order: sortOrder }[]>>;
+    sortOrder?: { id: string; order: sortOrderType }[];
+    setSortOrder?: React.Dispatch<React.SetStateAction<{ id: string; order: sortOrderType }[]>>;
 }
 
-export default function TableDesignContent({selectedRowIds, setSelectedRowIds, tableRows, setTableRows}: TableDesignContentProps) {
+export default function TableDesignContent({selectedRowIds, setSelectedRowIds, tableRows, setTableRows, sortOrder, setSortOrder}: TableDesignContentProps) {
   const translations = useTranslations("TableDesignContent"); 
   const handleRowSelect = (rowId: string) => {
     setSelectedRowIds((prev: string[]) => {
@@ -57,6 +57,28 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
         const originalPosition = getRowPosition(String(active.id));
         const newPosition = getRowPosition(String(over.id));
         return arrayMove(rows, originalPosition, newPosition);
+      });
+    }
+  };
+
+  // Handle sort order change for each row
+  const handleSortOrderChange = (rowId: string, newSortOrder: sortOrderType) => {
+    if (setSortOrder) {
+      setSortOrder((prev) => {
+        let updatedSortOrder = [...prev];
+        if (newSortOrder !== 'none') {
+          const existingIndex = updatedSortOrder.findIndex(item => item.id === rowId);
+          if (existingIndex !== -1) {
+            updatedSortOrder[existingIndex].order = newSortOrder;
+          } else {
+            updatedSortOrder.push({ id: rowId, order: newSortOrder });
+          }
+        } else {
+          // If the new order is 'none', remove the item from the sort array
+          updatedSortOrder = prev.filter(order => order.id !== rowId);
+        }
+        console.log("Updated Sort Order", updatedSortOrder);
+        return updatedSortOrder;
       });
     }
   };
@@ -100,14 +122,17 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
         </div>
         <SortableContext items={tableRows.map(row => row.id)} strategy={verticalListSortingStrategy}>
           {
-            tableRows.map((row) => (
-              <TableDesignRow 
+            tableRows.map((row) => {
+               const currentSort = sortOrder?.find(order => order.id === row.id);
+              return <TableDesignRow 
                 key={row.id} 
                 rowId={row.id} 
+                currentSortOrder={currentSort?.order || 'none'}
                 isSelected={selectedRowIds.includes(row.id)}
                 onSelect={handleRowSelect}
+                onSortOrderChange={handleSortOrderChange}
               />
-            )) 
+            }) 
           }
         </SortableContext>
         {

--- a/galasa-ui/src/components/test-runs/TableDesignContent.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignContent.tsx
@@ -77,7 +77,6 @@ export default function TableDesignContent({selectedRowIds, setSelectedRowIds, t
           // If the new order is 'none', remove the item from the sort array
           updatedSortOrder = prev.filter(order => order.id !== rowId);
         }
-        console.log("Updated Sort Order", updatedSortOrder);
         return updatedSortOrder;
       });
     }

--- a/galasa-ui/src/components/test-runs/TableDesignRow.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignRow.tsx
@@ -12,14 +12,17 @@ import { IconButton } from "@carbon/react";
 import {  Draggable } from "@carbon/icons-react";
 import { useTranslations } from "next-intl";
 import { Dropdown } from "@carbon/react";
+import { sortOrderType } from "@/utils/interfaces";
 
 interface TableDesignRowProps {
   rowId: string;
   isSelected: boolean;
+  currentSortOrder: sortOrderType,
   onSelect: (rowId: string) => void;
+  onSortOrderChange: (rowId: string, sortOrder: sortOrderType) => void;
 }
 
-export default function TableDesignRow({ rowId,  isSelected,  onSelect }: TableDesignRowProps) {
+export default function TableDesignRow({ rowId,  isSelected, currentSortOrder, onSelect, onSortOrderChange }: TableDesignRowProps) {
   const translations = useTranslations("TableDesignRow");
 
   const {
@@ -35,6 +38,14 @@ export default function TableDesignRow({ rowId,  isSelected,  onSelect }: TableD
     transform: CSS.Transform.toString(transform),
     transition,
   };
+
+  const sortItems = [
+    {text: translations('none'), value: 'none'}, 
+    {text: translations('asc'), value: 'asc'},
+    {text: translations('desc'), value: 'desc'}
+  ];
+
+  const initialItem = sortItems.find(item => item.value === currentSortOrder) || sortItems[0];
 
   return ( 
     <div 
@@ -68,14 +79,16 @@ export default function TableDesignRow({ rowId,  isSelected,  onSelect }: TableD
       <div className={styles.cellDropdown}>   
         <Dropdown 
           id={`dropdown-${rowId}`}
-          initialSelectedItem={{text: 'none'}}
-          items={[
-            translations('none'), 
-            translations('asc'),
-            translations('desc')
-          ]}
+          initialSelectedItem={initialItem}
+          items={sortItems}
           label="Sort Order"
           type="inline"
+          itemToString={(item: {text: string, value: string}) => item.text}
+          onChange={({ selectedItem }: {selectedItem: {text: string, value: sortOrderType}}) => {
+            if (selectedItem) {
+              onSortOrderChange(rowId, selectedItem.value);
+            }
+          }}
         />
       </div>
     </div>

--- a/galasa-ui/src/components/test-runs/TableDesignRow.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignRow.tsx
@@ -11,6 +11,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { IconButton } from "@carbon/react";
 import {  Draggable } from "@carbon/icons-react";
 import { useTranslations } from "next-intl";
+import { Dropdown } from "@carbon/react";
 
 interface TableDesignRowProps {
   rowId: string;
@@ -63,6 +64,20 @@ export default function TableDesignRow({ rowId,  isSelected,  onSelect }: TableD
       </div>
 
       <p className={styles.cellValue}>{translations(rowId)}</p>
+
+      <div className={styles.cellDropdown}>   
+        <Dropdown 
+          id={`dropdown-${rowId}`}
+          initialSelectedItem={{text: 'none'}}
+          items={[
+            translations('none'), 
+            translations('asc'),
+            translations('desc')
+          ]}
+          label="Sort Order"
+          type="inline"
+        />
+      </div>
     </div>
   );
 };

--- a/galasa-ui/src/components/test-runs/TableDesignRow.tsx
+++ b/galasa-ui/src/components/test-runs/TableDesignRow.tsx
@@ -45,7 +45,7 @@ export default function TableDesignRow({ rowId,  isSelected, currentSortOrder, o
     {text: translations('desc'), value: 'desc'}
   ];
 
-  const initialItem = sortItems.find(item => item.value === currentSortOrder) || sortItems[0];
+  const selectedItem = sortItems.find(item => item.value === currentSortOrder) || sortItems[0];
 
   return ( 
     <div 
@@ -79,7 +79,7 @@ export default function TableDesignRow({ rowId,  isSelected, currentSortOrder, o
       <div className={styles.cellDropdown}>   
         <Dropdown 
           id={`dropdown-${rowId}`}
-          initialSelectedItem={initialItem}
+          selectedItem={selectedItem}
           items={sortItems}
           label="Sort Order"
           type="inline"

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 "use client";
-
-import { Run } from "@/generated/galasaapi";
 import {
   DataTable,
   Table,
@@ -19,9 +17,11 @@ import {
   DataTableSkeleton,
 } from "@carbon/react";
 import {
+  ColumnDefinition,
   DataTableHeader,
   DataTableRow,
   DataTableCell as IDataTableCell,
+  runStructure,
 } from "@/utils/interfaces";
 import styles from "@/styles/TestRunsPage.module.css";
 import { TableRowProps } from "@carbon/react/lib/components/DataTable/TableRow";
@@ -42,36 +42,6 @@ interface CustomCellProps {
 }
 
 /**
- * Transforms and flattens the raw API data for Carbon DataTable.
- * @param runs - The array of run objects from the API.
- * @returns A new array of flat objects, each with a unique `id` and properties matching the headers.
- */
-const transformRunsforTable = (runs: Run[]) => {
-  if (!runs) {
-    return [];
-  }
-
-  return runs.map((run) => {
-    const structure = run.testStructure || {};
-
-    return {
-      id: run.runId,
-      submittedAt: structure.queued ? new Date(structure.queued).toLocaleString().replace(',', '') : 'N/A',
-      testRunName: structure.runName || 'N/A',
-      requestor: structure.requestor || 'N/A',
-      group: structure.group || 'N/A',
-      bundle: structure.bundle || 'N/A',
-      package: structure.testName?.substring(0, structure.testName.lastIndexOf('.')) || 'N/A',
-      testName: structure.testShortName || structure.testName || 'N/A',
-      tags: structure.tags ? structure.tags.join(', ') : 'N/A',
-      status: structure.status || 'N/A',
-      result: structure.result || 'N/A',
-      submissionId: structure.submissionId || 'N/A',
-    };
-  });
-};
-
-/**
  * This component encapsulates the logic for rendering a cell.
  * It renders a special layout for the 'result' column and a default for all others.
  */
@@ -88,10 +58,10 @@ const CustomCell = ({ header, value }: CustomCellProps) => {
 };
 
 interface TestRunsTableProps {
-  runsList: Run[];
+  runsList: runStructure[];
   limitExceeded: boolean;
   visibleColumns: string[];
-  orderedHeaders?: { id: string; columnName: string }[];
+  orderedHeaders?: ColumnDefinition[];
   isLoading?: boolean;
   isError?: boolean;
 }
@@ -110,15 +80,12 @@ export default function TestRunsTable({runsList,limitExceeded, visibleColumns, o
     header: translations(column.id)
   })) || [];
 
-  // Transform the raw runs data into a format suitable for the DataTable
-  const tableRows = useMemo(() => transformRunsforTable(runsList), [runsList]);
-
   // Calculate the paginated rows based on the current page and page size
   const paginatedRows = useMemo(() => {
     const startIndex = (currentPage - 1) * pageSize;
     const endIndex = startIndex + pageSize;
-    return tableRows.slice(startIndex, endIndex);
-  }, [tableRows, currentPage, pageSize]);
+    return runsList.slice(startIndex, endIndex);
+  }, [runsList, currentPage, pageSize]);
 
   // Generate the time frame text based on the runs data
   const timeFrameText = useMemo(() => {
@@ -128,7 +95,7 @@ export default function TestRunsTable({runsList,limitExceeded, visibleColumns, o
 
     let text = translations("timeFrameText.default");
     const dates = runsList.map((run) =>
-      new Date(run.testStructure?.queued || 0).getTime(),
+      new Date(run.submittedAt || 0).getTime(),
     );
     const earliestDate = new Date(Math.min(...dates));
     const latestDate = new Date(Math.max(...dates));
@@ -187,7 +154,7 @@ export default function TestRunsTable({runsList,limitExceeded, visibleColumns, o
     return <p>{translations('noColumnsSelected')}</p>;
   }
 
-  if ( !tableRows || tableRows.length === 0) {
+  if ( !runsList || runsList.length === 0) {
     return <p>{translations('noTestRunsFound')}</p>;
   }
 
@@ -248,7 +215,7 @@ export default function TestRunsTable({runsList,limitExceeded, visibleColumns, o
           page={currentPage}
           pageSize={pageSize}
           pageSizes={[10, 20, 30, 40, 50]}
-          totalItems={tableRows.length}
+          totalItems={runsList.length}
           onChange={handlePaginationChange}
         />
       </div>

--- a/galasa-ui/src/components/test-runs/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTable.tsx
@@ -201,7 +201,7 @@ export default function TestRunsTable({runsList,limitExceeded, visibleColumns, o
       />}
       <p className={styles.timeFrameText}>{timeFrameText}</p>
       <div className={styles.testRunsTableContainer}>
-        <DataTable isSortable rows={paginatedRows} headers={headers}>
+        <DataTable rows={paginatedRows} headers={headers}>
           {({
             rows,
             headers,

--- a/galasa-ui/src/components/test-runs/TestRunsTabs.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTabs.tsx
@@ -13,11 +13,11 @@ import TableDesignContent from './TableDesignContent';
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { TestRunsData } from "@/utils/testRuns";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { RESULTS_TABLE_COLUMNS, COLUMNS_IDS, RUN_QUERY_PARAMS} from '@/utils/constants/common';
 import { useQuery } from '@tanstack/react-query';
 import { ColumnDefinition, runStructure, sortOrderType } from '@/utils/interfaces';
-import { Run, TestStructure } from '@/generated/galasaapi';
+import { Run } from '@/generated/galasaapi';
 
 
 interface TabConfig {
@@ -84,7 +84,7 @@ export default function TestRunsTabs({ requestorNamesPromise, resultsNamesPromis
       });
     }
     return sortOrderArray;
-  })
+  });
     
   // State to track if the component has been initialized
   const [isInitialized, setIsInitialized] = useState(false);
@@ -221,7 +221,7 @@ export default function TestRunsTabs({ requestorNamesPromise, resultsNamesPromis
     const runsToSort = runsData?.runs ? transformRunsforTable(runsData.runs) : [];
 
     if (sortOrder.length !== 0 && runsToSort.length !== 0) {
-      return runsToSort.sort((runA, runB) => {
+      return [...runsToSort].sort((runA, runB) => {
         // Sort based on the order of columns in columnsOrder (Assumption: Leftmost has higher priority)
         for (const {id} of columnsOrder) {
           const sortConfig = sortOrder.find(order => order.id === id);
@@ -233,24 +233,19 @@ export default function TestRunsTabs({ requestorNamesPromise, resultsNamesPromis
 
           const valueA = runA[id] ?? '';
           const valueB = runB[id] ?? '';
-          console.log(`Sorting by ${id}: ${valueA} vs ${valueB}`);
 
-          // Handle tags array specifically if needed
-          const valA = Array.isArray(valueA) ? valueA.join(',') : valueA;
-          const valB = Array.isArray(valueB) ? valueB.join(',') : valueB;
+          const comparison = String(valueA).localeCompare(String(valueB));
 
-          if (valA < valB) {
-            return sortConfig.order === 'asc' ? -1 : 1;
-          } else if (valueA > valueB) {
-            return sortConfig.order === 'asc' ? 1 : -1;
+          if (comparison !== 0) {
+            return sortConfig.order === 'asc' ? comparison : -comparison;
           }
         }
         // If all compared columns are equal, maintain original order
         return 0;
-      })
+      });
     }
     return runsToSort;
-  }, [runsData, sortOrder, columnsOrder])
+  }, [runsData, sortOrder, columnsOrder]);
 
 
   return (

--- a/galasa-ui/src/components/test-runs/TestRunsTabs.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsTabs.tsx
@@ -16,7 +16,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { RESULTS_TABLE_COLUMNS, COLUMNS_IDS, RUN_QUERY_PARAMS} from '@/utils/constants/common';
 import { useQuery } from '@tanstack/react-query';
-import { sortOrder } from '@/utils/interfaces';
+import { sortOrderType } from '@/utils/interfaces';
 
 
 interface TabConfig {
@@ -72,13 +72,13 @@ export default function TestRunsTabs({ requestorNamesPromise, resultsNamesPromis
 
   // Initialize sortOrder based on URL parameters or default to an empty array
   // URL should look like this sortOrder?result:asc,status:desc
-  const [sortOrder, setSortOrder] = useState<{id: string; order: sortOrder}[]>(() => {
+  const [sortOrder, setSortOrder] = useState<{id: string; order: sortOrderType}[]>(() => {
     const sortOrderParam = searchParams.get(RUN_QUERY_PARAMS.SORT_ORDER);
-    let sortOrderArray: {id: string; order: sortOrder}[] = [];
+    let sortOrderArray: {id: string; order: sortOrderType}[] = [];
     if (sortOrderParam) {
       sortOrderArray = sortOrderParam.split(',').map((item) => {
         const [id, order] = item.split(':');
-        return { id, order: order as sortOrder };
+        return { id, order: order as sortOrderType };
       });
     }
     return sortOrderArray;
@@ -127,7 +127,7 @@ export default function TestRunsTabs({ requestorNamesPromise, resultsNamesPromis
     params.set(RUN_QUERY_PARAMS.COLUMNS_ORDER, columnsOrderParam);
 
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });
-  }, [selectedVisibleColumns, columnsOrder, isInitialized, pathname, router, selectedIndex]);
+  }, [selectedVisibleColumns, columnsOrder, isInitialized, pathname, router, selectedIndex, sortOrder]);
 
   const handleTabChange = (event: {selectedIndex : number}) => {
     const currentIndex = event.selectedIndex;

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -18,7 +18,6 @@
     margin: 0.5rem 0.5rem;
 }
 
-  
 .searchCriteriaContainer {
   display: flex;
   flex-direction: row; 
@@ -191,7 +190,7 @@
   border: 1px solid #a8a8a8; 
   border-radius: 0;
   width: 55%;
-  min-width: 400px;
+  min-width: 500px;
 }
 
 .tableDesignRow,
@@ -237,6 +236,15 @@
   font-size: 0.9rem;
 }
 
+.cellDropdown {
+  flex: 0 0 120px;
+  width: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 1rem;
+}
+
 /* Remove border from the very last row */
 .tableDesignContainer > div:last-child > .tableDesignRow:last-child {
   border-bottom: none;
@@ -261,6 +269,15 @@
   padding-left: 0.5rem;
   text-align: left;
 }
+
+.cellDropdownHeader {
+  flex: 0 0 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding-left: 1rem;
+}
+
 
 .dragging {
   opacity: 0.5;

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -275,7 +275,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 

--- a/galasa-ui/src/tests/components/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunsTable.test.tsx
@@ -8,8 +8,6 @@ import '@testing-library/jest-dom';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { fireEvent } from '@testing-library/react';
 import TestRunsTable from '@/components/test-runs/TestRunsTable';
-import { TestRunsData } from '@/utils/testRuns';
-import { useSearchParams } from 'next/navigation';
 import { MAX_RECORDS, RESULTS_TABLE_COLUMNS } from '@/utils/constants/common';
 
 // Mock the useRouter hook from Next.js to return a mock router object.
@@ -36,7 +34,7 @@ jest.mock("next-intl", () => ({
       "noColumnsSelected": "All of the columns have been hidden in the table design tab, so no result details will be visible.",
       "isloading": "Loading...",
       "submittedAt": "Submitted at",
-      "testRunName": "Test Run name",
+      "runName": "Test Run name",
       "requestor": "Requestor",
       "testName": "Test Name",
       "status": "Status",
@@ -63,33 +61,35 @@ jest.mock('@/app/error/page', () =>
 );
 
 jest.mock('@/components/common/StatusIndicator', () =>
-  function StatusIndicator() {
+  function StatusIndicator({status}: {status: string}) {
     return <div data-testid="status-indicator">Status: {status}</div>;
   }
 );
 
 // Helper function to generate mock test runs data
 const generateMockRuns = (count: number) => {
-  return Array.from({length: count}, (_, index) => ({
-    runId: `${index + 1}`,
-    testStructure: {
-      runName: `Test Run ${index + 1}`,
-      requestor: `user${index + 1}`,
-      group: `group${index + 1}`,
-      bundle: `bundle${index + 1}`,
-      package: `package${index + 1}`,
-      testName: `test${index + 1}`,
-      testShortName: `testShort${index + 1}`,
+  return Array.from({ length: count }, (_, index) => {
+    const i = index + 1;
+    return {
+      id: `${i}`,
+      runName: `Test Run ${i}`,
+      requestor: `user${i}`,
+      group: `group${i}`,
+      bundle: `bundle${i}`,
+      package: `package${i}`,
+      testName: `test${i}`,
       status: "finished",
-      result: index % 2 === 0 ? "Passed" : "Failed",
-      queued: new Date(Date.now() - index * 1000 * 60 * 60).toISOString(),
-    },
-  }));
+      result: i % 2 === 0 ? "Failed" : "Passed", 
+      submittedAt: new Date(Date.now() - i * 1000 * 60 * 60).toISOString(),
+      tags: `tag${i}`,
+      submissionId: `submission${i}`,
+    };
+  });
 };
 
 // Default props for TestRunsTable component
 const defaultProps = {
-  visibleColumns: ["submittedAt", "testRunName", "requestor", "testName", "status", "result"],
+  visibleColumns: ["submittedAt", "runName", "requestor", "testName", "status", "result"],
   orderedHeaders: RESULTS_TABLE_COLUMNS,
   limitExceeded: false,
   isLoading: false,

--- a/galasa-ui/src/tests/components/TestRunsTabs.test.tsx
+++ b/galasa-ui/src/tests/components/TestRunsTabs.test.tsx
@@ -8,10 +8,21 @@ import '@testing-library/jest-dom';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import TestRunsTabs from '@/components/test-runs/TestRunsTabs';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
-import { RUN_QUERY_PARAMS } from '@/utils/constants/common';
+import { stat } from 'fs';
 
 // Mock Child Components
-const TestRunsTableMock = jest.fn((props) => <div data-testid="test-runs-table">Mocked Test Runs Table</div>);
+const TestRunsTableMock = jest.fn((props) =>
+  <div>
+    <div data-testid="test-runs-table">
+    Mocked Test Runs Table
+    </div>
+    {
+      props.runsList.forEach((run: any) => {
+        const runId = run.id;
+        return <div key={runId}>{run.runName || runId}</div>;
+      })
+    }
+  </div>);
 jest.mock('@/components/test-runs/TestRunsTable', () => ({
   __esModule: true,
   default: (props: any) => TestRunsTableMock(props),
@@ -29,12 +40,14 @@ jest.mock('@/components/test-runs/SearchCriteriaContent', () => ({
 
 let capturedSetSelectedVisibleColumns: (columns: string[]) => void;
 let capturedSetColumnsOrder: (order: { id: string; columnName: string }[]) => void;
+let capturedSetSortOrder: (sortOrder: { id: string; order: 'asc' | 'desc' | 'none' }[]) => void;
 
 jest.mock('@/components/test-runs/TableDesignContent', () => ({
   __esModule: true,
   default: (props: any) => {
     capturedSetSelectedVisibleColumns = props.setSelectedRowIds;
     capturedSetColumnsOrder = props.setTableRows;
+    capturedSetSortOrder = props.setSortOrder;
     return <div>Mocked Table Design Content</div>;
   },
 }));
@@ -66,19 +79,21 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/utils/constants/common', () => ({
   RESULTS_TABLE_COLUMNS:  [
     { id: 'submittedAt', columnName: 'Submitted' },
-    { id: 'testRunName', columnName: 'Test Run Name' },
+    { id: 'runName', columnName: 'Test Run Name' },
     { id: 'requestor', columnName: 'Requestor' },
     { id: 'testName', columnName: 'Test Name' },
     { id: 'status', columnName: 'Status' },
     { id: 'result', columnName: 'Result' },
+    { id: 'tags', columnName: 'Tags' }
   ],
   COLUMNS_IDS: {
     SUBMITTED_AT: 'submittedAt',
-    TEST_RUN_NAME: 'testRunName',
+    TEST_RUN_NAME: 'runName',
     REQUESTOR: 'requestor',
     TEST_NAME: 'testName',
     STATUS: 'status',
     RESULT: 'result',
+    TAGS: 'tags',
   },  RUN_QUERY_PARAMS: {
     FROM: 'from',
     TO: 'to',
@@ -93,7 +108,8 @@ jest.mock('@/utils/constants/common', () => ({
     TAGS: 'tags',
     VISIBLE_COLUMNS: 'visibleColumns',
     COLUMNS_ORDER: 'columnsOrder',
-    TAB: 'tab'
+    TAB: 'tab',
+    SORT_ORDER: 'sortOrder',
   }
 }));
 
@@ -133,7 +149,6 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 
 describe('TestRunsTabs Component', () => {
-  const mockPromise = Promise.resolve({ runs: [], limitExceeded: false });
   const mockRequestorNamesPromise = Promise.resolve([]);
   const mockResultsNamesPromise = Promise.resolve([]);
 
@@ -232,12 +247,12 @@ describe('TestRunsTabs Component', () => {
       });
         
       const expectedParams = new URLSearchParams();
-      const defaultVisible = "submittedAt,testRunName,requestor,testName,status,result";
-      const defaultOrder = "submittedAt,testRunName,requestor,testName,status,result";
+      const defaultVisible = "submittedAt,runName,requestor,testName,status,result";
+      const defaultOrder = "submittedAt,runName,requestor,testName,status,result,tags";
       expectedParams.set('tab', 'timeframe');
       expectedParams.set('visibleColumns', defaultVisible);
       expectedParams.set('columnsOrder', defaultOrder);
-  
+
       expect(mockReplace).toHaveBeenCalledWith(`/?${expectedParams.toString()}`, { scroll: false });
     });
 
@@ -265,7 +280,7 @@ describe('TestRunsTabs Component', () => {
       const urlCall = mockReplace.mock.calls[0][0];
       const params = new URLSearchParams(urlCall.split('?')[1]);
       expect(params.get('visibleColumns')).toBe('status,result');
-      expect(params.get('columnsOrder')).toBe('submittedAt,testRunName,requestor,testName,status,result');
+      expect(params.get('columnsOrder')).toBe('submittedAt,runName,requestor,testName,status,result,tags');
     });
 
     test('updates URL when column order is changed', async () => {
@@ -293,7 +308,7 @@ describe('TestRunsTabs Component', () => {
       const urlCall = mockReplace.mock.calls[0][0];
       const params = new URLSearchParams(urlCall.split('?')[1]);
       expect(params.get('columnsOrder')).toBe('result,status');
-      expect(params.get('visibleColumns')).toBe('submittedAt,testRunName,requestor,testName,status,result');
+      expect(params.get('visibleColumns')).toBe('submittedAt,runName,requestor,testName,status,result');
     });
 
     test('clear visible columns in URL when none are selected', async () => {
@@ -320,6 +335,81 @@ describe('TestRunsTabs Component', () => {
       const urlCall = mockReplace.mock.calls[0][0];
       const params = new URLSearchParams(urlCall.split('?')[1]);
       expect(params.get('visibleColumns')).toBeNull();
+    });
+
+    test('updates URL when sort order is changed', async () => {
+      // Arrange
+      render(
+        <TestRunsTabs
+          requestorNamesPromise={mockRequestorNamesPromise}
+          resultsNamesPromise={mockResultsNamesPromise}
+        /> , { wrapper }
+      );
+
+      // Wait for the initial save
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1)); 
+      mockReplace.mockClear();
+  
+      // Act: Simulate a child component updating the sort order
+      act(() => {
+        capturedSetSortOrder([{ id: 'status', order: 'asc' }, { id: 'result', order: 'desc' }]);
+      });
+  
+      // Assert: The save-to-URL effect runs again with the new state
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1));
+  
+      const urlCall = mockReplace.mock.calls[0][0];
+      const params = new URLSearchParams(urlCall.split('?')[1]);
+      expect(params.get('sortOrder')).toBe('status:asc,result:desc');
+    });
+
+    test('clear sortOrder in URL when no certain order is specified', async () => {
+      // Arrange
+      render(
+        <TestRunsTabs
+          requestorNamesPromise={mockRequestorNamesPromise}
+          resultsNamesPromise={mockResultsNamesPromise}
+        /> , { wrapper }
+      );
+
+      // Wait for the initial save
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1)); 
+      mockReplace.mockClear();
+  
+      // Act: Simulate a child component clearing the visible columns
+      act(() => {
+        capturedSetSortOrder([]);
+      });
+  
+      // Assert: The save-to-URL effect runs again with the new state
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledTimes(1));
+  
+      const urlCall = mockReplace.mock.calls[0][0];
+      const params = new URLSearchParams(urlCall.split('?')[1]);
+      expect(params.get('sortOrder')).toBeNull();
+    });
+
+    test('initialize sortOrder state from URL parameter', async() => {
+      // Arrange: Provide specific URL parameters for this test
+      const params = new URLSearchParams();
+      params.set('sortOrder', 'status:asc,result:desc');
+      mockUseSearchParams.mockReturnValue(params);
+  
+      // Act
+      render(
+        <TestRunsTabs
+          requestorNamesPromise={mockRequestorNamesPromise}
+          resultsNamesPromise={mockResultsNamesPromise}
+        />, { wrapper }
+      );
+  
+      // Assert: Wait for the component to process the params and pass them as props
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalled();
+        const urlCall = mockReplace.mock.calls[0][0];
+        const newParams = new URLSearchParams(urlCall.split('?')[1]);
+        expect(newParams.get('sortOrder')).toBe('status:asc,result:desc');
+      });
     });
   });
 
@@ -457,4 +547,160 @@ describe('TestRunsTabs Component', () => {
     // Ensure a new fetch is triggered
     await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(3));
   });
-});
+
+  describe('Sorting Logic', () => {
+
+    const unsortedRuns = [
+      { runId: '1', testStructure: { runName: 'C Run', status: 'Passed', requestor: 'A User', tags: ['A tag'] } },
+      { runId: '2', testStructure: { runName: 'A Run', status: 'Failed', requestor: 'B User', tags: ['B tag'] } },
+      { runId: '3', testStructure: { runName: 'B Run', status: 'Passed', requestor: 'C User', tags: ['A tag', 'C tag']}},
+      { runId: '0', testStructure: { runName: 'D Run', status:'Passed', requestor: 'A User', tags: ['D tag', 'A tag']}}
+    ];
+
+    const defaultTransformedRun = {
+      bundle: "N/A", group: "N/A", package: "N/A", result: "N/A", submissionId: "N/A",
+      submittedAt: "N/A", testName: "N/A", runName: "N/A"
+    };
+
+    beforeEach(() => {
+      (global.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ runs: unsortedRuns, limitExceeded: false }),
+        })
+      );
+    });
+
+    test('sorts data by a single column in ascending order', async () => {
+      const params = new URLSearchParams();
+      params.set('sortOrder', 'runName:asc');
+      mockUseSearchParams.mockReturnValue(params);
+
+      render(
+        <TestRunsTabs requestorNamesPromise={Promise.resolve([])} resultsNamesPromise={Promise.resolve([])} />, 
+        { wrapper }
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'Results' }));
+
+      await waitFor(() => {
+        const lastCallArgs = TestRunsTableMock.mock.calls.slice(-1)[0][0];
+        expect(lastCallArgs.runsList).toEqual([
+          { ...defaultTransformedRun, id: '2', runName: 'A Run', status: 'Failed', requestor: 'B User', tags: 'B tag' },
+          { ...defaultTransformedRun, id: '3', runName: 'B Run', status: 'Passed', requestor: 'C User', tags: 'A tag, C tag' },
+          { ...defaultTransformedRun, id: '1', runName: 'C Run', status: 'Passed', requestor: 'A User', tags: 'A tag' },
+          { ...defaultTransformedRun, id: '0', runName: 'D Run', status:'Passed', requestor: 'A User', tags: 'D tag, A tag'}
+        ]);
+      });
+    });
+
+    test('sorts data by a single column in descending order', async () => {
+      const params = new URLSearchParams();
+      params.set('sortOrder', 'runName:desc');
+      mockUseSearchParams.mockReturnValue(params);
+
+      render(
+        <TestRunsTabs requestorNamesPromise={Promise.resolve([])} resultsNamesPromise={Promise.resolve([])} />, 
+        { wrapper }
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'Results' }));
+
+      await waitFor(() => {
+        const lastCallArgs = TestRunsTableMock.mock.calls.slice(-1)[0][0];
+        expect(lastCallArgs.runsList).toEqual([
+          { ...defaultTransformedRun, id: '0', runName: 'D Run', status:'Passed', requestor: 'A User', tags: 'D tag, A tag'},
+          { ...defaultTransformedRun, id: '1', runName: 'C Run', status: 'Passed', requestor: 'A User', tags: 'A tag' },
+          { ...defaultTransformedRun, id: '3', runName: 'B Run', status: 'Passed', requestor: 'C User', tags: 'A tag, C tag' },
+          { ...defaultTransformedRun, id: '2', runName: 'A Run', status: 'Failed', requestor: 'B User', tags: 'B tag' },
+        ]);
+      });
+    });
+
+    test('sorts by tags in ascending order', async () => {
+      const params = new URLSearchParams();
+      params.set('sortOrder', 'tags:asc');
+      mockUseSearchParams.mockReturnValue(params);
+
+      render(
+        <TestRunsTabs requestorNamesPromise={Promise.resolve([])} resultsNamesPromise={Promise.resolve([])} />, 
+        { wrapper }
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'Results' }));
+
+      await waitFor(() => {
+        const lastCallArgs = TestRunsTableMock.mock.calls.slice(-1)[0][0];
+        expect(lastCallArgs.runsList).toEqual([
+          { ...defaultTransformedRun, id: '1', runName: 'C Run', status: 'Passed', requestor: 'A User', tags: 'A tag' },
+          { ...defaultTransformedRun, id: '3', runName: 'B Run', status: 'Passed', requestor: 'C User', tags: 'A tag, C tag' },
+          { ...defaultTransformedRun, id: '2', runName: 'A Run', status: 'Failed', requestor: 'B User', tags: 'B tag' },
+          { ...defaultTransformedRun, id: '0', runName: 'D Run', status:'Passed', requestor: 'A User', tags: 'D tag, A tag'}
+        ]);
+      });
+    });
+
+
+    test('sorts correctly with two keys where primary key has higher column order', async () => {
+      const params = new URLSearchParams();
+      params.set('columnsOrder', 'requestor,testName,runName,result,tags');
+      params.set('sortOrder', 'runName:desc,requestor:asc');
+      mockUseSearchParams.mockReturnValue(params);
+
+      render(
+        <TestRunsTabs requestorNamesPromise={Promise.resolve([])} resultsNamesPromise={Promise.resolve([])} />, 
+        { wrapper }
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'Results' }));
+
+      await waitFor(() => {
+        const lastCallArgs = TestRunsTableMock.mock.calls.slice(-1)[0][0];
+        expect(lastCallArgs.runsList).toEqual([
+          { ...defaultTransformedRun, id: '0', runName: 'D Run', status:'Passed', requestor: 'A User', tags: 'D tag, A tag'},
+          { ...defaultTransformedRun, id: '1', runName: 'C Run', status: 'Passed', requestor: 'A User', tags: 'A tag' },
+          { ...defaultTransformedRun, id: '2', runName: 'A Run', status: 'Failed', requestor: 'B User', tags: 'B tag' },
+          { ...defaultTransformedRun, id: '3', runName: 'B Run', status: 'Passed', requestor: 'C User', tags: 'A tag, C tag' },
+        ]);
+      });
+    });
+
+
+    test('sorts correctly with three keys and handles ties at each level', async () => {
+      const mockedRuns = [
+        {runId: '1', testStructure: {requestor: 'A User', status: 'Passed', tags: ['B tag'] }},
+        {runId: '2', testStructure: {requestor: 'L User', status: 'Passed', tags: ['C tag']}},
+        {runId: '3', testStructure: {requestor: 'B User', status: 'Passed', tags: ['A tag']}},
+        {runId: '4', testStructure: {requestor: 'L User', status: 'Failed', tags: ['F tag']}},
+        {runId: '5', testStructure: {requestor: 'A User', status: 'Passed', tags: ['A tag, L tag']}},
+        {runId: '6', testStructure: {requestor: 'A User', status: 'Failed', tags: ['A tag, B tag']}}
+      ];
+
+      (global.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ runs: mockedRuns, limitExceeded: false }),
+        })
+      );
+
+      const params = new URLSearchParams();
+      params.set('columnsOrder', 'requestor,status,runName,result,tags');
+      params.set('sortOrder', 'requestor:desc,tags:asc,status:asc');
+      mockUseSearchParams.mockReturnValue(params);
+
+      render(
+        <TestRunsTabs requestorNamesPromise={Promise.resolve([])} resultsNamesPromise={Promise.resolve([])} />, 
+        { wrapper }
+      );
+      fireEvent.click(screen.getByRole('tab', { name: 'Results' }));
+
+      await waitFor(() => {
+        const lastCallArgs = TestRunsTableMock.mock.calls.slice(-1)[0][0];
+        expect(lastCallArgs.runsList).toEqual([
+          {...defaultTransformedRun, id: '4', requestor: 'L User', status: 'Failed', tags: 'F tag'},
+          {...defaultTransformedRun, id: '2', requestor: 'L User', status: 'Passed', tags: 'C tag'},
+          {...defaultTransformedRun, id: '3', requestor: 'B User', status: 'Passed', tags: 'A tag'},
+          {...defaultTransformedRun, id: '6', requestor: 'A User', status: 'Failed', tags: 'A tag, B tag'},
+          {...defaultTransformedRun, id: '5', requestor: 'A User', status: 'Passed', tags: 'A tag, L tag'},
+          {...defaultTransformedRun, id: '1', requestor: 'A User', status: 'Passed', tags: 'B tag' },
+        ]);
+      });
+    });
+  });
+}); 

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+import { TestStructure } from "@/generated/galasaapi";
+import { ColumnDefinition } from "../interfaces";
+
 const CLIENT_API_VERSION = "0.43.0";
 
 const COLORS = {
@@ -29,7 +32,7 @@ const TEST_RUNS_STATUS = ['Queued', 'Started', 'Generating',
 
 const COLUMNS_IDS = {
   SUBMITTED_AT: "submittedAt",
-  TEST_RUN_NAME: "testRunName",
+  TEST_RUN_NAME: "runName",
   REQUESTOR: "requestor",
   SUBMISSION_ID: "submissionId",
   GROUP: "group",
@@ -41,9 +44,9 @@ const COLUMNS_IDS = {
   RESULT: "result"
 } as const;
 
-const RESULTS_TABLE_COLUMNS = [
-  {id: "submittedAt", columnName: "Submitted at"},
-  { id: "testRunName", columnName: "Test Run name" },
+const RESULTS_TABLE_COLUMNS: ColumnDefinition[] = [
+  { id: "submittedAt", columnName: "Submitted at" },
+  { id: "runName", columnName: "Test Run name" },
   { id: "requestor", columnName: "Requestor" },
   { id: "submissionId", columnName: "Submission ID" },
   { id: "group", columnName: "Group" },

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -70,7 +70,8 @@ const RUN_QUERY_PARAMS = {
   TAGS: "tags",
   VISIBLE_COLUMNS: "visibleColumns",
   COLUMNS_ORDER: "columnsOrder",
-  TAB: "tab"
+  TAB: "tab",
+  SORT_ORDER: "sortOrder",
 };
   
 const BATCH_SIZE = 100;

--- a/galasa-ui/src/utils/interfaces/common.ts
+++ b/galasa-ui/src/utils/interfaces/common.ts
@@ -14,7 +14,7 @@ export interface MarkdownResponse {
 }
 
 export type AmPm = 'AM' | 'PM';
-export type sortOrder = 'asc' | 'desc' | 'none';
+export type sortOrderType = 'asc' | 'desc' | 'none';
 
 // DataTableHeader, DataTableCell, DataTableRow are IBM Carbon interfaces
 export interface DataTableHeader {

--- a/galasa-ui/src/utils/interfaces/common.ts
+++ b/galasa-ui/src/utils/interfaces/common.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+import { TestStructure } from "@/generated/galasaapi";
+
 /**
  * Common interfaces used across multiple components and utilities
  */
@@ -40,4 +42,24 @@ export interface DataTableRow {
   disabled?: boolean;
   isExpanded?: boolean;
   isSelected?: boolean;
+}
+
+export interface runStructure {
+  submittedAt: string;
+  runName: string;
+  requestor: string;
+  group: string;
+  bundle: string;
+  package: string;
+  testName: string;
+  tags:  string;
+  status: string;
+  result: string;
+  submissionId: string;
+}
+
+
+export interface ColumnDefinition {
+  id: keyof runStructure;
+  columnName: string;
 }

--- a/galasa-ui/src/utils/interfaces/common.ts
+++ b/galasa-ui/src/utils/interfaces/common.ts
@@ -14,6 +14,7 @@ export interface MarkdownResponse {
 }
 
 export type AmPm = 'AM' | 'PM';
+export type sortOrder = 'asc' | 'desc' | 'none';
 
 // DataTableHeader, DataTableCell, DataTableRow are IBM Carbon interfaces
 export interface DataTableHeader {


### PR DESCRIPTION
## Why?
Closes [https://github.com/galasa-dev/projectmanagement/issues/2286](https://github.com/galasa-dev/projectmanagement/issues/2286)
## Changes 
- Introduced a new *"Sort Order"* column in the results table to enable multi-level sorting based on user-defined priority.
- Synced the sort state with the URL, making it shareable and bookmarkable.
- Added unit tests covering multiple sorting scenarios.