### PR TITLE
Implement Share Support and Copy Feedback on Test Runs Page

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -147,7 +147,27 @@
     "title": "Testläufe",
     "status": "Wird geladen..."
   },
-  "MySettings": {
+  "MySettings": {  "TestRunDetails": {
+    "title": "Test Run: {runName}",
+    "errorTitle": "Error",
+    "successTitle": "Success",
+    "copyMessage":"Copy page URL",
+    "copiedTitle":"URL copy successful: ",
+    "copiedMessage":"The URL for this page has been copied to the clipboard.",
+    "copyFailedMessage":"Failed to copy page URL",
+    "downloadArtifacts": "Download all artifacts",
+    "downloading": "Downloading...",
+    "downloadError": "Failed to download artifacts. Please try again later.",
+    "status": "Status",
+    "result": "Result",
+    "test": "Test",
+    "tabs": {
+      "overview": "Overview",
+      "methods": "Methods",
+      "runLog": "Run Log",
+      "artifacts": "Artifacts"
+    }
+  },
     "title": "Meine Einstellungen"
   },
   "MyProfilePage": {
@@ -215,8 +235,12 @@
   "TestRunDetails": {
     "title": "Testlauf: {runName}",
     "status": "Status",
-    "copymessage": "Seiten-URL kopieren",
-    "copiedmessage": "Kopiert",
+    "errorTitle": "Fehler",
+    "successTitle": "Erfolg",
+    "copyMessage": "Seiten-URL kopieren",
+    "copiedTitle": "URL erfolgreich kopiert: ",
+    "copiedMessage": "Die URL dieser Seite wurde in die Zwischenablage kopiert.",
+    "copyFailedMessage": "Fehler beim Kopieren der Seiten-URL",
     "downloadArtifacts": "Alle Artefakte herunterladen",
     "downloading": "Herunterladen...",
     "downloadError": "Fehler beim Herunterladen der Artefakte. Bitte versuchen Sie es später erneut.",
@@ -227,8 +251,7 @@
       "methods": "Methoden",
       "runLog": "Laufprotokoll",
       "artifacts": "Artefakte"
-    },
-    "errorTitle": "Fehler"
+    }
   },
   "TestRunSkeleton": {
     "status": "Status",

--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -253,6 +253,15 @@
       "artifacts": "Artefakte"
     }
   },
+  "TestRunsDetails": {
+    "title":  "Testläufe",
+    "errorTitle": "Fehler",
+    "successTitle": "Erfolg",
+    "copyMessage": "Seiten-URL kopieren",
+    "copiedTitle": "URL erfolgreich kopiert: ",
+    "copiedMessage": "Die URL dieser Seite wurde in die Zwischenablage kopiert.",
+    "copyFailedMessage": "Fehler beim Kopieren der Seiten-URL"
+  },
   "TestRunSkeleton": {
     "status": "Status",
     "result": "Ergebnis",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -233,6 +233,15 @@
       "artifacts": "Artifacts"
     }
   },
+  "TestRunsDetails": {
+    "title": "Test Runs",
+    "errorTitle": "Error",
+    "successTitle": "Success",
+    "copyMessage": "Copy page URL",
+    "copiedTitle": "URL copy successful: ",
+    "copiedMessage": "The URL for this page has been copied to the clipboard.",
+    "copyFailedMessage": "Failed to copy page URL"
+  },
   "TestRunSkeleton": {
     "status": "Status",
     "result": "Result",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -214,8 +214,12 @@
   },
   "TestRunDetails": {
     "title": "Test Run: {runName}",
-    "copymessage":"Copy page URL",
-    "copiedmessage":"Copied",
+    "errorTitle": "Error",
+    "successTitle": "Success",
+    "copyMessage":"Copy page URL",
+    "copiedTitle":"URL copy successful: ",
+    "copiedMessage":"The URL for this page has been copied to the clipboard.",
+    "copyFailedMessage":"Failed to copy page URL",
     "downloadArtifacts": "Download all artifacts",
     "downloading": "Downloading...",
     "downloadError": "Failed to download artifacts. Please try again later.",
@@ -227,8 +231,7 @@
       "methods": "Methods",
       "runLog": "Run Log",
       "artifacts": "Artifacts"
-    },
-    "errorTitle": "Error"
+    }
   },
   "TestRunSkeleton": {
     "status": "Status",

--- a/galasa-ui/src/components/PageTile.tsx
+++ b/galasa-ui/src/components/PageTile.tsx
@@ -12,10 +12,19 @@ import { useTranslations } from "next-intl";
 
 export default function PageTile({
   translationKey,
+  className,
+  children,
 }: {
   translationKey: string;
+  className?: string;
+  children?: React.ReactNode;
 }) {
   const translations = useTranslations();
 
-  return <Tile id="tile">{translations(translationKey)}</Tile>;
+  return (
+    <Tile id="tile" className={className}>
+      {translations(translationKey)}
+      {children}
+    </Tile>
+  );
 }

--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -120,8 +120,8 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
         subtitle: translations("copiedMessage")
       });
 
-      // Hide notification after 10 seconds
-      setTimeout(() => setNotification(null), 10000);
+      // Hide notification after 6 seconds
+      setTimeout(() => setNotification(null), 6000);
     } catch (err) {
       console.error('Failed to copy:', err);
       setNotification({
@@ -245,6 +245,7 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
           subtitle={notification.subtitle}
           className={styles.notification}
           kind={notification.kind}
+          hideCloseButton={true}
         />
       )}
       {isLoading ? (

--- a/galasa-ui/src/components/test-runs/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunDetails.tsx
@@ -28,6 +28,7 @@ import { Button } from '@carbon/react';
 import { useDateTimeFormat } from '@/contexts/DateTimeFormatContext';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {SINGLE_RUN_QUERY_PARAMS, TEST_RUN_PAGE_TABS} from '@/utils/constants/common';
+import { NotificationType } from '@/utils/types/common';
 
 interface TestRunDetailsProps {
   runId: string;
@@ -52,7 +53,7 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
   const [isError, setIsError] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
   const [copied, setCopied] = useState(false);
-  const [notificationError, setNotificationError] = useState<string | null>(null);
+  const [notification, setNotification] = useState<NotificationType | null>(null);
   const { formatDate } = useDateTimeFormat();
 
   // Get the selected tab index from the URL or default to the first tab
@@ -113,10 +114,21 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000); 
+      setNotification({
+        kind: 'success',
+        title: translations("copiedTitle"),
+        subtitle: translations("copiedMessage")
+      });
+
+      // Hide notification after 10 seconds
+      setTimeout(() => setNotification(null), 10000);
     } catch (err) {
       console.error('Failed to copy:', err);
+      setNotification({
+        kind: 'error',
+        title: translations("errorTitle"),
+        subtitle: translations("copyFailedMessage")
+      });
     }
   };
 
@@ -124,7 +136,7 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
     if (!run) return;
     
     setIsDownloading(true);
-    setNotificationError(null); 
+    setNotification(null); 
 
     try {
       const url = new URL(`/internal-api/test-runs/${run.runId}/zip`, window.location.origin);
@@ -151,7 +163,11 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
       handleDownload(blob, filename);
 
     } catch (err) {
-      setNotificationError("downloadError");
+      setNotification({
+        kind: 'error',
+        title: translations("errorTitle"),
+        subtitle: translations("downloadError")
+      });
       console.error("Failed to create zip file:", err);
     } finally {
       setIsDownloading(false);
@@ -217,21 +233,20 @@ const TestRunDetails = ({ runId, runDetailsPromise, runLogPromise, runArtifactsP
             kind="ghost"
             hasIconOnly
             renderIcon={Share}
-            iconDescription={copied ? translations("copiedmessage") : translations("copymessage")}
+            iconDescription={translations("copyMessage")}
             onClick={handleShare}
             data-testid="icon-Share"
           />
         </div>
       </Tile>
-      {notificationError && (
+      {notification && (
         <InlineNotification
-          title={translations("errorTitle")}
-          subtitle={translations(notificationError) || "An unexpected error occurred."}
+          title={notification.title}
+          subtitle={notification.subtitle}
           className={styles.notification}
-          kind="error"
+          kind={notification.kind}
         />
-      )}    
- 
+      )}
       {isLoading ? (
         <TestRunSkeleton />
       ) : (

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -4,12 +4,17 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 "use client";
-import PageTile from "@/components/PageTile";
 import BreadCrumb from "@/components/common/BreadCrumb";
 import TestRunsTabs from "@/components/test-runs/TestRunsTabs";
 import styles from "@/styles/TestRunsPage.module.css";
-import { Suspense } from "react";
+import { Suspense, useState } from "react";
 import useHistoryBreadCrumbs from "@/hooks/useHistoryBreadCrumbs";
+import { useTranslations } from "next-intl";
+import { NotificationType } from "@/utils/types/common";
+import { Button } from "@carbon/react";
+import { Share } from "@carbon/icons-react";
+import { Tile } from "@carbon/react";
+import { InlineNotification } from "@carbon/react";
 
 interface TestRunsDetailsProps {
     requestorNamesPromise: Promise<string[]>;
@@ -18,11 +23,56 @@ interface TestRunsDetailsProps {
 
 export default function TestRunsDetails({requestorNamesPromise, resultsNamesPromise}: TestRunsDetailsProps) {
   const { breadCrumbItems } = useHistoryBreadCrumbs();
+  const translations = useTranslations("TestRunsDetails");
+
+  const [notification, setNotification] = useState<NotificationType | null>(null);
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setNotification({
+        kind: 'success',
+        title: translations("copiedTitle"),
+        subtitle: translations("copiedMessage")
+      });
+
+      // Hide notification after 10 seconds
+      setTimeout(() => setNotification(null), 10000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      setNotification({
+        kind: 'error',
+        title: translations("errorTitle"),
+        subtitle: translations("copyFailedMessage")
+      });
+    }
+  };
       
   return(
     <main id="content">
       <BreadCrumb breadCrumbItems={breadCrumbItems} />
-      <PageTile translationKey={"TestRun.title"} />
+      
+      <Tile className={styles.toolbar} id="tile">
+        {translations("title")}
+        <div className={styles.buttonContainer}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            renderIcon={Share}
+            iconDescription={translations("copyMessage")}
+            onClick={handleShare}
+            data-testid="share-button"
+          />
+        </div>
+      </Tile>
+      {notification && (
+        <InlineNotification
+          title={notification.title}
+          subtitle={notification.subtitle}
+          className={styles.notification}
+          kind={notification.kind}
+        />
+      )}
       <div className={styles.testRunsContentWrapper}>
         <Suspense fallback={<p>Loading...</p>}>
           <TestRunsTabs

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -13,8 +13,8 @@ import { useTranslations } from "next-intl";
 import { NotificationType } from "@/utils/types/common";
 import { Button } from "@carbon/react";
 import { Share } from "@carbon/icons-react";
-import { Tile } from "@carbon/react";
 import { InlineNotification } from "@carbon/react";
+import PageTile from "../PageTile";
 
 interface TestRunsDetailsProps {
     requestorNamesPromise: Promise<string[]>;
@@ -51,20 +51,16 @@ export default function TestRunsDetails({requestorNamesPromise, resultsNamesProm
   return(
     <main id="content">
       <BreadCrumb breadCrumbItems={breadCrumbItems} />
-      
-      <Tile className={styles.toolbar} id="tile">
-        {translations("title")}
-        <div className={styles.buttonContainer}>
-          <Button
-            kind="ghost"
-            hasIconOnly
-            renderIcon={Share}
-            iconDescription={translations("copyMessage")}
-            onClick={handleShare}
-            data-testid="share-button"
-          />
-        </div>
-      </Tile>
+      <PageTile translationKey="TestRun.title" className={styles.toolbar}>
+        <Button
+          kind="ghost"
+          hasIconOnly
+          renderIcon={Share}
+          iconDescription={translations("copyMessage")}
+          onClick={handleShare}
+          data-testid="share-button"
+        />
+      </PageTile>
       {notification && (
         <InlineNotification
           title={notification.title}

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -37,7 +37,7 @@ export default function TestRunsDetails({requestorNamesPromise, resultsNamesProm
       });
 
       // Hide notification after 6 seconds
-      setTimeout(() => setNotification(null), 20000);
+      setTimeout(() => setNotification(null), 6000);
     } catch (err) {
       console.error('Failed to copy:', err);
       setNotification({

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -52,22 +52,25 @@ export default function TestRunsDetails({requestorNamesPromise, resultsNamesProm
     <main id="content">
       <BreadCrumb breadCrumbItems={breadCrumbItems} />
       <PageTile translationKey="TestRun.title" className={styles.toolbar}>
-        <Button
-          kind="ghost"
-          hasIconOnly
-          renderIcon={Share}
-          iconDescription={translations("copyMessage")}
-          onClick={handleShare}
-          data-testid="share-button"
-        />
+        <div className={styles.toolbarActions}>
+          <Button
+            kind="ghost"
+            hasIconOnly
+            renderIcon={Share}
+            iconDescription={translations("copyMessage")}
+            onClick={handleShare}
+            data-testid="share-button"
+          />
+        </div>
       </PageTile>
       {notification && (
-        <InlineNotification
-          title={notification.title}
-          subtitle={notification.subtitle}
-          className={styles.notification}
-          kind={notification.kind}
-        />
+        <div className={styles.notification}>
+          <InlineNotification
+            title={notification.title}
+            subtitle={notification.subtitle}
+            kind={notification.kind}
+          />
+        </div>
       )}
       <div className={styles.testRunsContentWrapper}>
         <Suspense fallback={<p>Loading...</p>}>

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -36,8 +36,8 @@ export default function TestRunsDetails({requestorNamesPromise, resultsNamesProm
         subtitle: translations("copiedMessage")
       });
 
-      // Hide notification after 10 seconds
-      setTimeout(() => setNotification(null), 10000);
+      // Hide notification after 6 seconds
+      setTimeout(() => setNotification(null), 20000);
     } catch (err) {
       console.error('Failed to copy:', err);
       setNotification({
@@ -69,6 +69,7 @@ export default function TestRunsDetails({requestorNamesPromise, resultsNamesProm
             title={notification.title}
             subtitle={notification.subtitle}
             kind={notification.kind}
+            hideCloseButton={true}
           />
         </div>
       )}

--- a/galasa-ui/src/styles/TestRun.module.css
+++ b/galasa-ui/src/styles/TestRun.module.css
@@ -40,8 +40,9 @@
     margin-right: 3rem;
 }
 
-.notification {
-    position: absolute;
+.notification{
+    position: fixed;
+    bottom: 5.5rem;
     right: 1rem;
-    top: 1rem;
+    z-index: 9999;
 }

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -306,3 +306,16 @@
 .hidden {
   visibility: hidden;
 }
+
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.buttonContainer{
+  display: flex;
+  margin-right: 3rem;
+  flex-shrink: 0;
+}

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -311,12 +311,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-}
-
-.buttonContainer{
-  display: flex;
-  margin-right: 3rem;
-  flex-shrink: 0;
+  padding-right: 3rem;
+  padding-top: 0;
 }
 
 .clickableRow {

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -308,12 +308,19 @@
 }
 
 .toolbar {
+  position: relative; 
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding-right: 3rem;
   height: 64px;
 }
+
+.toolbarActions {
+  position: absolute;
+  top: 50%;
+  right: 3rem; 
+  transform: translateY(-50%);
+}
+
 
 .clickableRow {
   cursor: pointer;

--- a/galasa-ui/src/styles/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/TestRunsPage.module.css
@@ -312,7 +312,7 @@
   align-items: center;
   justify-content: space-between;
   padding-right: 3rem;
-  padding-top: 0;
+  height: 64px;
 }
 
 .clickableRow {

--- a/galasa-ui/src/utils/types/common.ts
+++ b/galasa-ui/src/utils/types/common.ts
@@ -6,3 +6,9 @@
 
 export type AmPm = 'AM' | 'PM';
 export type sortOrderType = 'asc' | 'desc' | 'none';
+
+export type NotificationType = {
+  kind: 'error' | 'success' | 'info' | 'warning';
+  title: string;
+  subtitle: string;
+}


### PR DESCRIPTION
## Why?
Addresses feedback from [this comment](https://github.com/galasa-dev/projectmanagement/issues/2330#issuecomment-3098931302) and completes the work required to close [#2330](https://github.com/galasa-dev/projectmanagement/issues/2330).
## Changes
- Show success/error notifications when copying the page URL.
- Extend the share functionality to the Test Runs page.
- Add unit tests to cover the updated behavior.