### PR TITLE
feat: persist and use default items per page setting for test runs results table

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -66,6 +66,11 @@
     "deleteButtontext": "{count} ausgewählte Zugriffstoken löschen",
     "error": "Fehler beim Abrufen der Token vom Galasa API-Server"
   },
+  "ResultsTablePageSizingSetting": {
+    "title": "Testergebnisabfrage",
+    "description": "Durch Ändern dieser Einstellung wird die Standardanzahl der Testergebnisse festgelegt, die in der Tabelle für alle Ihre Abfragen pro Seite angezeigt werden.",
+    "defaultTestRunsLabel": "Standardanzahl der Testergebnisse pro Seite"
+  },
   "userRole": {
     "heading": "Benutzerrolle",
     "description": "Welche Aktionen ein Benutzer im Galasa-Dienst ausführen darf, wird durch seine Benutzerrolle bestimmt.",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -67,7 +67,7 @@
     "error": "Failed to fetch tokens from the Galasa API server"
   },
   "ResultsTablePageSizingSetting": {
-    "title": "Test run query results",
+    "title": "Test Run Query Results",
     "description": "Modifying this setting changes the default number of test run results which are shown on the test run table for all your queries.",
     "defaultTestRunsLabel": "Default test run records per page of results"
   },

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -66,6 +66,11 @@
     "deleteButtontext": "Delete {count} selected access token",
     "error": "Failed to fetch tokens from the Galasa API server"
   },
+  "ResultsTablePageSizingSetting": {
+    "title": "Test run query results",
+    "description": "Modifying this setting changes the default number of test run results which are shown on the test run table for all your queries.",
+    "defaultTestRunsLabel": "Default test run records per page of results"
+  },
   "userRole": {
     "heading": "User Role",
     "description": "The actions a user can or cannot perform on this Galasa service is controlled by their user role.",

--- a/galasa-ui/src/app/mysettings/page.tsx
+++ b/galasa-ui/src/app/mysettings/page.tsx
@@ -19,6 +19,7 @@ import { HOME } from '@/utils/constants/breadcrumb';
 import { fetchUserFromApiServer } from '@/actions/userServerActions';
 import ProfileRole from '@/components/users/UserRole';
 import DateTimeSettings from '@/components/mysettings/DateTimeSettings';
+import ResultsTablePageSizingSetting from '@/components/mysettings/ResultsTablePageSizingSetting';
 export default async function MySettings() {
   const apiConfig = createAuthenticatedApiConfiguration();
 
@@ -65,6 +66,7 @@ export default async function MySettings() {
       />
       <TokenResponseModal refreshToken={refreshToken} clientId={clientId} onLoad={deleteCookies} />
       <DateTimeSettings />
+      <ResultsTablePageSizingSetting />
       <ExperimentalFeaturesSection />
     </main>
   );

--- a/galasa-ui/src/app/mysettings/page.tsx
+++ b/galasa-ui/src/app/mysettings/page.tsx
@@ -19,7 +19,7 @@ import { HOME } from '@/utils/constants/breadcrumb';
 import { fetchUserFromApiServer } from '@/actions/userServerActions';
 import ProfileRole from '@/components/users/UserRole';
 import DateTimeSettings from '@/components/mysettings/DateTimeSettings';
-import ResultsTablePageSizingSetting from '@/components/mysettings/ResultsTablePageSizingSetting';
+import ResultsTablePageSizeSetting from '@/components/mysettings/ResultsTablePageSizeSetting';
 export default async function MySettings() {
   const apiConfig = createAuthenticatedApiConfiguration();
 
@@ -66,7 +66,7 @@ export default async function MySettings() {
       />
       <TokenResponseModal refreshToken={refreshToken} clientId={clientId} onLoad={deleteCookies} />
       <DateTimeSettings />
-      <ResultsTablePageSizingSetting />
+      <ResultsTablePageSizeSetting />
       <ExperimentalFeaturesSection />
     </main>
   );

--- a/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
+++ b/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
@@ -9,9 +9,12 @@ import { RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
 import { Dropdown } from '@carbon/react';
 import { useTranslations } from 'next-intl';
 import styles from '@/styles/mysettings/ResultsTablePageSizingSetting.module.css';
+import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
 
 export default function ResultsTablePageSizingSetting() {
   const translations = useTranslations('ResultsTablePageSizingSetting');
+  const { defaultPageSize, setDefaultPageSize } = useResultsTablePageSize();
+
   return (
     <section className={styles.section}>
       <h3 className={styles.heading}>{translations('title')}</h3>
@@ -23,12 +26,8 @@ export default function ResultsTablePageSizingSetting() {
             data-testid="custom-items-per-page-dropdown-test"
             items={RESULTS_TABLE_PAGE_SIZES}
             itemToString={(item: number) => item.toString()}
-            // selectedItem={RESULTS_TABLE_PAGE_SIZES.find(
-            //   (item) => item === preferences.itemsPerPage
-            // )}
-            // onChange={(e: { selectedItem: number }) =>
-
-            // }
+            selectedItem={defaultPageSize}
+            onChange={(e: { selectedItem: number }) => setDefaultPageSize(e.selectedItem)}
             size="md"
           />
         </div>

--- a/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
+++ b/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
@@ -10,28 +10,35 @@ import { Dropdown } from '@carbon/react';
 import { useTranslations } from 'next-intl';
 import styles from '@/styles/mysettings/ResultsTablePageSizingSetting.module.css';
 import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
+import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
+import { FEATURE_FLAGS } from '@/utils/featureFlags';
 
 export default function ResultsTablePageSizingSetting() {
   const translations = useTranslations('ResultsTablePageSizingSetting');
+  const { isFeatureEnabled } = useFeatureFlags();
   const { defaultPageSize, setDefaultPageSize } = useResultsTablePageSize();
 
   return (
-    <section className={styles.section}>
-      <h3 className={styles.heading}>{translations('title')}</h3>
-      <div>
-        <p className={styles.title}>{translations('description')}</p>
-        <div className={styles.dropdownContainer}>
-          <p>{translations('defaultTestRunsLabel')}</p>
-          <Dropdown
-            data-testid="custom-items-per-page-dropdown-test"
-            items={RESULTS_TABLE_PAGE_SIZES}
-            itemToString={(item: number) => item.toString()}
-            selectedItem={defaultPageSize}
-            onChange={(e: { selectedItem: number }) => setDefaultPageSize(e.selectedItem)}
-            size="md"
-          />
-        </div>
-      </div>
-    </section>
+    <>
+      {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS) && (
+        <section className={styles.section}>
+          <h3 className={styles.heading}>{translations('title')}</h3>
+          <div>
+            <p className={styles.title}>{translations('description')}</p>
+            <div className={styles.dropdownContainer}>
+              <p>{translations('defaultTestRunsLabel')}</p>
+              <Dropdown
+                data-testid="custom-items-per-page-dropdown-test"
+                items={RESULTS_TABLE_PAGE_SIZES}
+                itemToString={(item: number) => item.toString()}
+                selectedItem={defaultPageSize}
+                onChange={(e: { selectedItem: number }) => setDefaultPageSize(e.selectedItem)}
+                size="md"
+              />
+            </div>
+          </div>
+        </section>
+      )}
+    </>
   );
 }

--- a/galasa-ui/src/components/mysettings/ResultsTablePageSizingSetting.tsx
+++ b/galasa-ui/src/components/mysettings/ResultsTablePageSizingSetting.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+'use client';
+
+import { RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
+import { Dropdown } from '@carbon/react';
+import { useTranslations } from 'next-intl';
+
+export default function ResultsTablePageSizingSetting() {
+  const translations = useTranslations('ResultsTablePageSizingSetting');
+  return (
+    <section>
+      <h3>{translations('title')}</h3>
+      <div>
+        <p>{translations('description')}</p>
+        <div>
+          <p>{translations('defaultTestRunsLabel')}</p>
+          <Dropdown
+            data-testid="custom-items-per-page-dropdown-test"
+            items={RESULTS_TABLE_PAGE_SIZES}
+            itemToString={(item: number) => item.toString()}
+            // selectedItem={RESULTS_TABLE_PAGE_SIZES.find(
+            //   (item) => item === preferences.itemsPerPage
+            // )}
+            // onChange={(e: { selectedItem: number }) =>
+
+            // }
+            size="md"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/galasa-ui/src/components/mysettings/ResultsTablePageSizingSetting.tsx
+++ b/galasa-ui/src/components/mysettings/ResultsTablePageSizingSetting.tsx
@@ -8,15 +8,16 @@
 import { RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
 import { Dropdown } from '@carbon/react';
 import { useTranslations } from 'next-intl';
+import styles from '@/styles/mysettings/ResultsTablePageSizingSetting.module.css';
 
 export default function ResultsTablePageSizingSetting() {
   const translations = useTranslations('ResultsTablePageSizingSetting');
   return (
-    <section>
-      <h3>{translations('title')}</h3>
+    <section className={styles.section}>
+      <h3 className={styles.heading}>{translations('title')}</h3>
       <div>
-        <p>{translations('description')}</p>
-        <div>
+        <p className={styles.title}>{translations('description')}</p>
+        <div className={styles.dropdownContainer}>
           <p>{translations('defaultTestRunsLabel')}</p>
           <Dropdown
             data-testid="custom-items-per-page-dropdown-test"

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -31,7 +31,7 @@ import StatusIndicator from '../../common/StatusIndicator';
 import { useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import ErrorPage from '@/app/error/page';
-import { MAX_DISPLAYABLE_TEST_RUNS } from '@/utils/constants/common';
+import { MAX_DISPLAYABLE_TEST_RUNS, RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
 import { useTranslations } from 'next-intl';
 import { InlineNotification } from '@carbon/react';
 import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
@@ -39,6 +39,7 @@ import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 import { useDateTimeFormat } from '@/contexts/DateTimeFormatContext';
 import { useDisappearingNotification } from '@/hooks/useDisappearingNotification';
 import { getTimeframeText } from '@/utils/functions/timeFrameText';
+import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
 
 interface CustomCellProps {
   header: string;
@@ -78,7 +79,10 @@ export default function TestRunsTable({
   const searchParams = useSearchParams();
 
   const [currentPage, setCurrentPage] = useState(1);
-  const [pageSize, setPageSize] = useState(10);
+
+  // Get the default page size from the custom hook (which is set in the settings page)
+  const { defaultPageSize } = useResultsTablePageSize();
+  const [pageSize, setPageSize] = useState(defaultPageSize);
 
   const isNotificationVisible = useDisappearingNotification(limitExceeded);
 
@@ -261,7 +265,7 @@ export default function TestRunsTable({
           pageNumberText={translations('pagination.pageNumberText')}
           page={currentPage}
           pageSize={pageSize}
-          pageSizes={[10, 20, 30, 40, 50]}
+          pageSizes={RESULTS_TABLE_PAGE_SIZES}
           totalItems={runsList.length}
           onChange={handlePaginationChange}
         />

--- a/galasa-ui/src/hooks/useResultsTablePageSize.tsx
+++ b/galasa-ui/src/hooks/useResultsTablePageSize.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+'use client';
+
+import { RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
+import { useEffect, useState } from 'react';
+
+const LOCAL_STORAGE_KEY = 'resultsTablePageSize';
+
+export default function useResultsTablePageSize() {
+  const [defaultPageSize, setDefaultPageSize] = useState<number>(() => {
+    // Load the default page size initially from the localStorage
+    const storedPageSize = localStorage.getItem(LOCAL_STORAGE_KEY);
+    return storedPageSize ? Number(storedPageSize) : RESULTS_TABLE_PAGE_SIZES[0];
+  });
+
+  // Save the default page size to localStorage whenever changed
+  useEffect(() => {
+    if (defaultPageSize !== null) {
+      localStorage.setItem(LOCAL_STORAGE_KEY, String(defaultPageSize));
+    }
+  }, [defaultPageSize]);
+
+  return {
+    defaultPageSize,
+    setDefaultPageSize,
+  };
+}

--- a/galasa-ui/src/styles/mysettings/ResultsTablePageSizingSetting.module.css
+++ b/galasa-ui/src/styles/mysettings/ResultsTablePageSizingSetting.module.css
@@ -22,7 +22,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  padding: 0.5rem 1.5rem;
+  padding: 0.5rem 0.5rem;
 }
 
 .dropdownContainer :global(.cds--dropdown) {

--- a/galasa-ui/src/styles/mysettings/ResultsTablePageSizingSetting.module.css
+++ b/galasa-ui/src/styles/mysettings/ResultsTablePageSizingSetting.module.css
@@ -1,0 +1,31 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+.section {
+  width: 90%;
+  margin: 3rem auto;
+}
+
+.heading {
+  font-weight: 500;
+}
+
+.title {
+  font-weight: 500;
+  margin: 1rem 0;
+}
+
+.dropdownContainer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.5rem 1.5rem;
+}
+
+.dropdownContainer :global(.cds--dropdown) {
+  width: auto;
+  min-width: 5rem;
+}

--- a/galasa-ui/src/tests/__snapshots__/mysettings.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/mysettings.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`MySettings Component renders correctly when user login id is found 1`] 
     refreshToken=""
   />
   <DateTimeSettings />
+  <ResultsTablePageSizingSetting />
   <ExperimentalFeaturesSection />
 </main>
 `;

--- a/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
@@ -28,35 +28,69 @@ jest.mock('@/hooks/useResultsTablePageSize', () => ({
   }),
 }));
 
+// Mock useFeatureFlag hook
+const mockIsFeatureEnabled = jest.fn();
+jest.mock('@/contexts/FeatureFlagContext', () => ({
+  __esModule: true,
+  useFeatureFlags: () => ({
+    isFeatureEnabled: mockIsFeatureEnabled,
+  }),
+}));
+
 describe('ResultsTablePageSizingSetting', () => {
-  test('renders without crashing', () => {
-    render(<ResultsTablePageSizingSetting />);
-
-    expect(screen.getByText('Test Run Query Results')).toBeInTheDocument();
-    expect(
-      screen.getByText('Configure the number of results displayed per page.')
-    ).toBeInTheDocument();
-    expect(screen.getByTestId('custom-items-per-page-dropdown-test')).toBeInTheDocument();
+  beforeEach(() => {
+    mockIsFeatureEnabled.mockClear();
+    mockSetDefaultPageSize.mockClear();
   });
 
-  test('default page size is applied', () => {
-    render(<ResultsTablePageSizingSetting />);
+  describe('when feature flag is enabled', () => {
+    beforeEach(() => {
+      mockIsFeatureEnabled.mockReturnValue(true);
+    });
 
-    const dropdown = screen.getByTestId('custom-items-per-page-dropdown-test');
-    expect(within(dropdown).getByText('20')).toBeInTheDocument();
+    test('renders without crashing', () => {
+      render(<ResultsTablePageSizingSetting />);
+
+      expect(screen.getByText('Test Run Query Results')).toBeInTheDocument();
+      expect(
+        screen.getByText('Configure the number of results displayed per page.')
+      ).toBeInTheDocument();
+      expect(screen.getByTestId('custom-items-per-page-dropdown-test')).toBeInTheDocument();
+    });
+
+    test('default page size is applied', () => {
+      render(<ResultsTablePageSizingSetting />);
+
+      const dropdown = screen.getByTestId('custom-items-per-page-dropdown-test');
+      expect(within(dropdown).getByText('20')).toBeInTheDocument();
+    });
+
+    test('dropdown change calls setDefaultPageSize with the selected size', () => {
+      render(<ResultsTablePageSizingSetting />);
+
+      const dropdownWrapper = screen.getByTestId('custom-items-per-page-dropdown-test');
+      const dropdownButton = within(dropdownWrapper).getByRole('combobox');
+
+      // Open the dropdown and click on '50'
+      fireEvent.click(dropdownButton);
+      fireEvent.click(screen.getByText('50'));
+
+      // Assert that the mock function was called with the correct argument
+      expect(mockSetDefaultPageSize).toHaveBeenCalledWith(50);
+    });
   });
 
-  test('dropdown change calls setDefaultPageSize with the selected size', () => {
-    render(<ResultsTablePageSizingSetting />);
+  describe('when feature flag is disabled', () => {
+    beforeEach(() => {
+      mockIsFeatureEnabled.mockReturnValue(false);
+    });
 
-    const dropdownWrapper = screen.getByTestId('custom-items-per-page-dropdown-test');
-    const dropdownButton = within(dropdownWrapper).getByRole('combobox');
+    test('does not render the component', () => {
+      render(<ResultsTablePageSizingSetting />);
 
-    // Open the dropdown and click on '50'
-    fireEvent.click(dropdownButton);
-    fireEvent.click(screen.getByText('50'));
-
-    // Assert that the mock function was called with the correct argument
-    expect(mockSetDefaultPageSize).toHaveBeenCalledWith(50);
+      expect(screen.queryByText('Test Run Query Results')).toBeNull();
+      expect(screen.queryByText('Configure the number of results displayed per page.')).toBeNull();
+      expect(screen.queryByTestId('custom-items-per-page-dropdown-test')).toBeNull();
+    });
   });
 });

--- a/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import React from 'react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import ResultsTablePageSizingSetting from '@/components/mysettings/ResultsTablePageSizeSetting';
+
+// Mock the next-intl module to provide translations
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => {
+    const translations: Record<string, string> = {
+      title: 'Test Run Query Results',
+      description: 'Configure the number of results displayed per page.',
+    };
+    return translations[key] || key;
+  },
+}));
+
+// Mock useResultsTablePageSize hook
+const mockSetDefaultPageSize = jest.fn();
+jest.mock('@/hooks/useResultsTablePageSize', () => ({
+  __esModule: true,
+  default: () => ({
+    defaultPageSize: 20,
+    setDefaultPageSize: mockSetDefaultPageSize,
+  }),
+}));
+
+describe('ResultsTablePageSizingSetting', () => {
+  test('renders without crashing', () => {
+    render(<ResultsTablePageSizingSetting />);
+
+    expect(screen.getByText('Test Run Query Results')).toBeInTheDocument();
+    expect(
+      screen.getByText('Configure the number of results displayed per page.')
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('custom-items-per-page-dropdown-test')).toBeInTheDocument();
+  });
+
+  test('default page size is applied', () => {
+    render(<ResultsTablePageSizingSetting />);
+
+    const dropdown = screen.getByTestId('custom-items-per-page-dropdown-test');
+    expect(within(dropdown).getByText('20')).toBeInTheDocument();
+  });
+
+  test('dropdown change calls setDefaultPageSize with the selected size', () => {
+    render(<ResultsTablePageSizingSetting />);
+
+    const dropdownWrapper = screen.getByTestId('custom-items-per-page-dropdown-test');
+    const dropdownButton = within(dropdownWrapper).getByRole('combobox');
+
+    // Open the dropdown and click on '50'
+    fireEvent.click(dropdownButton);
+    fireEvent.click(screen.getByText('50'));
+
+    // Assert that the mock function was called with the correct argument
+    expect(mockSetDefaultPageSize).toHaveBeenCalledWith(50);
+  });
+});

--- a/galasa-ui/src/tests/hooks/useResultsTablePageSize.test.tsx
+++ b/galasa-ui/src/tests/hooks/useResultsTablePageSize.test.tsx
@@ -49,7 +49,7 @@ describe('useResultsTablePageSize', () => {
     });
 
     await waitFor(() => {
-      expect(localStorage.getItem('resultsTablePageSize')).toBe(JSON.stringify(30));
+      expect(localStorage.getItem('resultsTablePageSize')).toBe(String(30));
     });
   });
 
@@ -58,7 +58,7 @@ describe('useResultsTablePageSize', () => {
 
     await waitFor(() => {
       // Default is 10
-      expect(localStorage.getItem('resultsTablePageSize')).toBe(JSON.stringify(10));
+      expect(localStorage.getItem('resultsTablePageSize')).toBe(String(10));
     });
   });
 });

--- a/galasa-ui/src/tests/hooks/useResultsTablePageSize.test.tsx
+++ b/galasa-ui/src/tests/hooks/useResultsTablePageSize.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem(key: string) {
+      return store[key] || null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value.toString();
+    },
+    clear() {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+});
+
+describe('useResultsTablePageSize', () => {
+  // reset localStorage before each test
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('should initialize from localStorage', async () => {
+    localStorage.setItem('resultsTablePageSize', JSON.stringify(20));
+    const { result } = renderHook(() => useResultsTablePageSize());
+
+    await waitFor(() => {
+      expect(result.current.defaultPageSize).toBe(20);
+    });
+  });
+
+  test('should update localStorage when page size changes', async () => {
+    const { result } = renderHook(() => useResultsTablePageSize());
+
+    act(() => {
+      result.current.setDefaultPageSize(30);
+    });
+
+    await waitFor(() => {
+      expect(localStorage.getItem('resultsTablePageSize')).toBe(JSON.stringify(30));
+    });
+  });
+
+  test('should reset to default page size when the key is not stored in localStorage', async () => {
+    const { result } = renderHook(() => useResultsTablePageSize());
+
+    await waitFor(() => {
+      // Default is 10
+      expect(localStorage.getItem('resultsTablePageSize')).toBe(JSON.stringify(10));
+    });
+  });
+});

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -156,6 +156,8 @@ const PREFERENCE_KEYS = {
 
 const TEST_RUN_PAGE_TABS = ['overview', 'methods', 'runLog', 'artifacts'];
 
+const RESULTS_TABLE_PAGE_SIZES = [10, 20, 30, 40, 50];
+
 export {
   CLIENT_API_VERSION,
   COLORS,
@@ -179,4 +181,5 @@ export {
   TEST_RUN_PAGE_TABS,
   SINGLE_RUN_QUERY_PARAMS,
   LOCALE_TO_FLATPICKR_FORMAT_MAP,
+  RESULTS_TABLE_PAGE_SIZES,
 };


### PR DESCRIPTION
## Why?
Closes [https://github.com/galasa-dev/projectmanagement/issues/2364](https://github.com/galasa-dev/projectmanagement/issues/2364)
## Changes
- Added a new “Results table default items per page” section in the My Settings page.
-  Introduced a custom hook to save and retrieve the default page size from `localStorage`.
-  Updated the results table to use the saved preference by default.
- **Tests**
  - Unit tests for the new hook.
  - Unit tests for the new settings component.
  - Tests ensuring the results table retreives its default page size from the hook.