### PR TITLE
Improve time display and recent runs logic

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -320,8 +320,7 @@
     "limitExceededSubtitle": "Ihre Abfrage hat mehr als {maxRecords} Ergebnisse zurückgegeben. Es werden die ersten {maxRecords} Datensätze angezeigt. Um dies in Zukunft zu vermeiden, schränken Sie Ihren Zeitrahmen ein oder ändern Sie Ihre Suchkriterien, um weniger Ergebnisse zu erhalten.",
     "timeFrameText": {
       "default": "Zeige Testläufe der letzten 24 Stunden",
-      "range": "Zeige Testläufe von {from} bis {to}",
-      "isRelativeToNow": "Zeige die neuesten Testläufe von vor {days} Tagen, {hours} Stunden und {minutes} Minuten"
+      "range": "Zeige Testläufe von {from} bis {to}"
     },
     "noColumnsSelected": "Alle Spalten wurden im Tabellen-Design-Tab ausgeblendet, sodass keine Ergebniseinzelheiten sichtbar sein werden. Bitte passen Sie das Tabellen-Design an, um die gewünschten Spalten anzuzeigen.",
     "pagination": {
@@ -359,8 +358,7 @@
     },
 
     "timeFrameText": {
-      "range": "Zeige Testläufe von {from} bis {to}",
-      "isRelativeToNow": "Zeige die neuesten Testläufe von vor {days} Tagen, {hours} Stunden und {minutes} Minuten"
+      "range": "Zeige Testläufe von {from} bis {to}"
     }
   },
   "TestRunsTabs": {

--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -384,7 +384,7 @@
     "envelopeDescription": "Testläufe, die innerhalb dieses Zeitraums eingereicht wurden, werden in den Ergebnissen angezeigt, sofern andere Filter angewendet werden.",
     "invalidTimeFrame": "Ungültiger Zeitraum",
     "autoCorrection": "Automatische Korrektur",
-    "toBeforeFromAutoAdjust": "Sie haben eine 'Von'-Zeit ausgewählt, die neuer ist als die 'Bis'-Zeit. Dies ist kein gültiger Zeitraum. Die 'Bis'-Zeit wurde so angepasst, dass sie etwas neuer ist als die von Ihnen gewählte 'Von'-Zeit.",
+    "toBeforeFromErrorMessage": "Die 'Von'-Zeit muss vor der 'Bis'-Zeit liegen. Wählen Sie einen gültigen Zeitraum aus.",
     "toBeforeFromWarningOnly": "'Von'-Zeitpunkt ist in der Zukunft. Die aktuelle Abfrage liefert keine Ergebnisse.",
     "dateRangeExceeded": "Der Datumsbereich darf {maxMonths} Monate nicht überschreiten; das 'Bis'-Datum wurde angepasst.",
     "dateRangeCapped": "Der Datumsbereich wurde auf die aktuelle Zeit begrenzt.",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -362,7 +362,7 @@
     "envelopeDescription": "Test runs submitted within this period will be shown in the results, subject to other filters being applied.",
     "invalidTimeFrame": "Invalid Time Frame",
     "autoCorrection": "Auto-Correction",
-    "toBeforeFromAutoAdjust": "You selected a 'From' time which is more recent than the 'To' time. This is not a valid time period. The 'To' time has been changed to be slightly more recent than your selected 'From' time.",
+    "toBeforeFromErrorMessage": "The 'From' time must be earlier than the 'To' time. Select a valid time range.",
     "toBeforeFromWarningOnly": "'From' time is set to the future. Current query will return no results.",
     "dateRangeExceeded": "Date range cannot exceed {maxMonths} months; 'To' date has been adjusted.",
     "dateRangeCapped": "Date range was capped at the current time.",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -299,8 +299,7 @@
     "limitExceededSubtitle": "Your query returned more than {maxRecords} results. Showing the first {maxRecords} records. To avoid this in the future narrow your time frame or change your search criteria to return fewer results.",
     "timeFrameText": {
       "default": "Showing test runs submitted in the last 24 hours",
-      "range": "Showing test runs submitted between {from} and {to}",
-      "isRelativeToNow": "Showing the most recent test runs from {days} days, {hours} hours and {minutes} minutes ago"
+      "range": "Showing test runs submitted between {from} and {to}"
     },
     "noColumnsSelected": "All of the columns have been hidden in the table design tab, so no result details will be visible. Please adjust the table design to show the columns that you would like to see.",
     "pagination": {
@@ -337,8 +336,7 @@
       "subtitle": "Your query returned more than {maxRecords} results. Showing the first {maxRecords} records. To avoid this in the future narrow your time frame or change your search criteria to return fewer results."
     },
     "timeFrameText": {
-      "range": "Showing test runs submitted between {from} and {to}",
-      "isRelativeToNow": "Showing the most recent test runs from {days} days, {hours} hours and {minutes} minutes ago"
+      "range": "Showing test runs submitted between {from} and {to}"
     }
   },
   "TestRunsTabs": {

--- a/galasa-ui/src/components/test-runs/graph/TestRunsGraph.tsx
+++ b/galasa-ui/src/components/test-runs/graph/TestRunsGraph.tsx
@@ -231,24 +231,8 @@ export default function TestRunGraph({
 
   // Generate the time frame text based on the runs data
   const timeFrameText = useMemo(() => {
-    return getTimeframeText(
-      runsList,
-      isRelativeToNow,
-      durationDays,
-      durationHours,
-      durationMinutes,
-      translations,
-      formatDate
-    );
-  }, [
-    runsList,
-    translations,
-    formatDate,
-    isRelativeToNow,
-    durationDays,
-    durationHours,
-    durationMinutes,
-  ]);
+    return getTimeframeText(runsList, translations, formatDate);
+  }, [runsList, translations, formatDate]);
 
   if (isError) {
     return <p>{translations('errorLoadingGraph')}</p>;

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -103,24 +103,8 @@ export default function TestRunsTable({
 
   // Generate the time frame text based on the runs data
   const timeFrameText = useMemo(() => {
-    return getTimeframeText(
-      runsList,
-      isRelativeToNow,
-      durationDays,
-      durationHours,
-      durationMinutes,
-      translations,
-      formatDate
-    );
-  }, [
-    runsList,
-    translations,
-    formatDate,
-    isRelativeToNow,
-    durationDays,
-    durationHours,
-    durationMinutes,
-  ]);
+    return getTimeframeText(runsList, translations, formatDate);
+  }, [runsList, translations, formatDate]);
 
   if (isError) {
     return <ErrorPage />;

--- a/galasa-ui/src/components/test-runs/test-run-details/OverviewTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/OverviewTab.tsx
@@ -23,10 +23,8 @@ const OverviewTab = ({ metadata }: { metadata: RunMetadata }) => {
 
   const [weekBefore, setWeekBefore] = useState<string | null>(null);
 
-  const MONTH_AGO = getOneMonthAgo();
-
-  const fullTestName = metadata?.package + '.' + metadata?.testName;
-  const OTHER_RECENT_RUNS = `/test-runs?${TEST_RUNS_QUERY_PARAMS.TEST_NAME}=${fullTestName}&${TEST_RUNS_QUERY_PARAMS.BUNDLE}=${metadata?.bundle}&${TEST_RUNS_QUERY_PARAMS.PACKAGE}=${metadata?.package}&${TEST_RUNS_QUERY_PARAMS.FROM}=${MONTH_AGO}&${TEST_RUNS_QUERY_PARAMS.TAB}=results`;
+  const fullTestName = metadata?.testName;
+  const OTHER_RECENT_RUNS = `/test-runs?${TEST_RUNS_QUERY_PARAMS.TEST_NAME}=${fullTestName}&${TEST_RUNS_QUERY_PARAMS.BUNDLE}=${metadata?.bundle}&${TEST_RUNS_QUERY_PARAMS.PACKAGE}=${metadata?.package}&${TEST_RUNS_QUERY_PARAMS.DURATION}=60,0,0&${TEST_RUNS_QUERY_PARAMS.TAB}=results`;
   const RETRIES_FOR_THIS_TEST_RUN = `/test-runs?${TEST_RUNS_QUERY_PARAMS.SUBMISSION_ID}=${metadata?.submissionId}&${TEST_RUNS_QUERY_PARAMS.FROM}=${weekBefore}&${TEST_RUNS_QUERY_PARAMS.TAB}=results`;
   useEffect(() => {
     const validateTime = () => {

--- a/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
@@ -70,7 +70,6 @@ const TestRunDetails = ({
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
   const [isDownloading, setIsDownloading] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [notification, setNotification] = useState<NotificationType | null>(null);
   const { formatDate } = useDateTimeFormat();
 

--- a/galasa-ui/src/components/test-runs/timeframe/DurationFilter.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/DurationFilter.tsx
@@ -10,7 +10,6 @@ import { FormGroup, NumberInput } from '@carbon/react';
 import { useTranslations } from 'next-intl';
 import styles from '@/styles/test-runs/timeframe/TimeFrameContent.module.css';
 
-const MAX_DAYS = 90;
 const MAX_HOURS = 23;
 const MAX_MINUTES = 59;
 
@@ -36,13 +35,13 @@ export default function DurationFilter({
           id="duration-days"
           label={translations('days')}
           min={0}
-          max={MAX_DAYS}
           value={values.durationDays}
           onChange={(
             _: React.ChangeEvent<HTMLInputElement>,
             { value }: { value: number | string }
           ) => handleValueChange('durationDays', value)}
           disabled={disabled}
+          className={styles.durationInput}
         />
         <NumberInput
           id="duration-hours"
@@ -55,6 +54,7 @@ export default function DurationFilter({
             { value }: { value: number | string }
           ) => handleValueChange('durationHours', value)}
           disabled={disabled}
+          className={styles.durationInput}
         />
         <NumberInput
           id="duration-minutes"
@@ -67,6 +67,7 @@ export default function DurationFilter({
             { value }: { value: number | string }
           ) => handleValueChange('durationMinutes', value)}
           disabled={disabled}
+          className={styles.durationInput}
         />
       </div>
     </FormGroup>

--- a/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
@@ -9,9 +9,9 @@ import styles from '@/styles/test-runs/timeframe/TimeFrameContent.module.css';
 import { TimeFrameValues } from '@/utils/interfaces';
 import { useState, useCallback, useEffect } from 'react';
 import TimeFrameFilter from './TimeFrameFilter';
-import { addMonths, dateTimeLocal2UTC, dateTimeUTC2Local } from '@/utils/timeOperations';
+import { dateTimeLocal2UTC, dateTimeUTC2Local } from '@/utils/timeOperations';
 import { InlineNotification } from '@carbon/react';
-import { MAX_RANGE_MONTHS, DAY_MS, HOUR_MS, MINUTE_MS } from '@/utils/constants/common';
+import { DAY_MS, HOUR_MS, MINUTE_MS } from '@/utils/constants/common';
 import { useTranslations } from 'next-intl';
 import { useDateTimeFormat } from '@/contexts/DateTimeFormatContext';
 import DurationFilter from './DurationFilter';
@@ -207,24 +207,7 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
       <FormGroup className={styles.formGroup} legendText="" role="radiogroup">
         <div className={styles.fromContainer}>
           <h3 className={styles.heading}>{translations('from')}</h3>
-          <div className={styles.optionRow}>
-            <RadioButton
-              labelText={translations('specificTimeTitle')}
-              value={FromSelectionOptions.specificFromTime}
-              id="from-specific-time"
-              name="from-timeframe-options"
-              checked={selectedFromOption === FromSelectionOptions.specificFromTime}
-              onChange={() => setSelectedFromOption(FromSelectionOptions.specificFromTime)}
-            />
-            <div className={styles.filterWrapper}>
-              <TimeFrameFilter
-                values={values}
-                handleValueChange={handleValueChange}
-                fromToSelection={fromToSelectionEnum.FromSelectionOptions}
-                disabled={selectedFromOption !== FromSelectionOptions.specificFromTime}
-              />
-            </div>
-          </div>
+
           <div className={styles.optionRow}>
             <RadioButton
               labelText={
@@ -251,12 +234,44 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
               />
             </div>
           </div>
+          <div className={styles.optionRow}>
+            <RadioButton
+              labelText={translations('specificTimeTitle')}
+              value={FromSelectionOptions.specificFromTime}
+              id="from-specific-time"
+              name="from-timeframe-options"
+              checked={selectedFromOption === FromSelectionOptions.specificFromTime}
+              onChange={() => setSelectedFromOption(FromSelectionOptions.specificFromTime)}
+            />
+            <div className={styles.filterWrapper}>
+              <TimeFrameFilter
+                values={values}
+                handleValueChange={handleValueChange}
+                fromToSelection={fromToSelectionEnum.FromSelectionOptions}
+                disabled={selectedFromOption !== FromSelectionOptions.specificFromTime}
+              />
+            </div>
+          </div>
         </div>
 
         <div className={styles.divider}></div>
 
         <div className={styles.toContainer}>
           <h3 className={styles.heading}>{translations('to')}</h3>
+          <div className={styles.optionRow}>
+            <RadioButton
+              labelText={translations('nowTitle')}
+              value={ToSelectionOptions.now}
+              id="to-now"
+              name="to-timeframe-options"
+              checked={selectedToOption === ToSelectionOptions.now}
+              onChange={() => {
+                setSelectedToOption(ToSelectionOptions.now);
+                handleValueChange('isRelativeToNow', true);
+              }}
+            />
+            <p className={styles.nowDescription}>{translations('nowDescription')}</p>
+          </div>
           <div className={styles.optionRow}>
             <RadioButton
               labelText={translations('specificTimeTitle')}
@@ -277,20 +292,6 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
                 disabled={selectedToOption !== ToSelectionOptions.specificToTime}
               />
             </div>
-          </div>
-          <div className={styles.optionRow}>
-            <RadioButton
-              labelText={translations('nowTitle')}
-              value={ToSelectionOptions.now}
-              id="to-now"
-              name="to-timeframe-options"
-              checked={selectedToOption === ToSelectionOptions.now}
-              onChange={() => {
-                setSelectedToOption(ToSelectionOptions.now);
-                handleValueChange('isRelativeToNow', true);
-              }}
-            />
-            <p className={styles.nowDescription}>{translations('nowDescription')}</p>
           </div>
         </div>
       </FormGroup>

--- a/galasa-ui/src/styles/test-runs/timeframe/TimeFrameContent.module.css
+++ b/galasa-ui/src/styles/test-runs/timeframe/TimeFrameContent.module.css
@@ -64,6 +64,10 @@
   gap: 1rem;
 }
 
+.durationInput {
+  max-width: 150px;
+}
+
 .notification {
   position: fixed;
   bottom: 5.5rem;

--- a/galasa-ui/src/tests/components/test-runs/test-run-details/OverviewTab.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/test-run-details/OverviewTab.test.tsx
@@ -31,7 +31,6 @@ jest.mock('@carbon/react', () => ({
 }));
 
 jest.mock('@/utils/timeOperations', () => ({
-  getOneMonthAgo: jest.fn(),
   getAWeekBeforeSubmittedTime: jest.fn(),
 }));
 
@@ -83,7 +82,6 @@ const completeMetadata: RunMetadata = {
   tags: ['smoke', 'regression'],
 };
 
-const mockGetOneMonthAgo = getOneMonthAgo as jest.MockedFunction<typeof getOneMonthAgo>;
 const mockGetAWeekBeforeSubmittedTime = getAWeekBeforeSubmittedTime as jest.MockedFunction<
   typeof getAWeekBeforeSubmittedTime
 >;
@@ -138,13 +136,10 @@ describe('OverviewTab', () => {
 
 describe('OverviewTab - Time and Link Logic', () => {
   beforeEach(() => {
-    mockGetOneMonthAgo.mockReset();
     mockGetAWeekBeforeSubmittedTime.mockReset();
   });
 
   it('renders recent runs link with correct href', async () => {
-    const mockMonthAgoDate = '2025-05-10T00:00:00Z';
-    mockGetOneMonthAgo.mockReturnValue(mockMonthAgoDate);
     mockGetAWeekBeforeSubmittedTime.mockReturnValue('2025-06-03T09:00:00Z');
 
     render(<OverviewTab metadata={completeMetadata} />);
@@ -154,7 +149,7 @@ describe('OverviewTab - Time and Link Logic', () => {
     const links = screen.getAllByTestId('mock-link');
     const recentRunsLink = links.find((link) => link.getAttribute('href')?.includes('testName='));
 
-    const expectedHref = `/test-runs?testName=${completeMetadata.package}.${completeMetadata.testName}&bundle=${completeMetadata.bundle}&package=${completeMetadata.package}&from=${mockMonthAgoDate.toString()}&tab=results`;
+    const expectedHref = `/test-runs?testName=${completeMetadata.testName}&bundle=${completeMetadata.bundle}&package=${completeMetadata.package}&duration=60,0,0&tab=results`;
 
     expect(recentRunsLink).toHaveAttribute('href', expectedHref);
   });
@@ -163,7 +158,6 @@ describe('OverviewTab - Time and Link Logic', () => {
     const mockMonthAgoDate = '2025-05-10T00:00:00Z';
     const mockWeekBefore = '2025-06-03T09:00:00Z';
 
-    mockGetOneMonthAgo.mockReturnValue(mockMonthAgoDate);
     mockGetAWeekBeforeSubmittedTime.mockReturnValue(mockWeekBefore);
 
     render(<OverviewTab metadata={completeMetadata} />);
@@ -182,9 +176,6 @@ describe('OverviewTab - Time and Link Logic', () => {
   });
 
   it('renders only recent runs link when weekBefore is invalid', async () => {
-    const mockMonthAgoDate = '2025-05-10T00:00:00Z';
-
-    mockGetOneMonthAgo.mockReturnValue(mockMonthAgoDate);
     mockGetAWeekBeforeSubmittedTime.mockReturnValue(null);
 
     render(<OverviewTab metadata={completeMetadata} />);
@@ -204,7 +195,6 @@ describe('OverviewTab - Time and Link Logic', () => {
       rawSubmittedAt: '2025-06-10T09:00:00Z',
     };
 
-    const mockMonthAgoDate = '2025-05-10T00:00:00Z';
     mockGetAWeekBeforeSubmittedTime.mockReturnValue('2025-06-03T09:00:00Z');
 
     render(<OverviewTab metadata={metadataWithRawSubmittedAt} />);
@@ -213,23 +203,12 @@ describe('OverviewTab - Time and Link Logic', () => {
     expect(mockGetAWeekBeforeSubmittedTime).toHaveBeenCalledTimes(1);
   });
 
-  it('calls getOneMonthAgo during component initialization', () => {
-    const mockMonthAgoDate = '2025-05-10T00:00:00Z';
-    mockGetAWeekBeforeSubmittedTime.mockReturnValue('2025-06-03T09:00:00Z');
-
-    render(<OverviewTab metadata={completeMetadata} />);
-
-    expect(mockGetOneMonthAgo).toHaveBeenCalled();
-    expect(mockGetOneMonthAgo).toHaveBeenCalledWith();
-  });
-
   it('handles missing rawSubmittedAt gracefully', () => {
     const metadataWithoutRawSubmittedAt: RunMetadata = {
       ...completeMetadata,
       rawSubmittedAt: undefined,
     };
 
-    mockGetOneMonthAgo.mockReturnValue('2025-05-10T00:00:00Z');
     mockGetAWeekBeforeSubmittedTime.mockReturnValue('Invalid date');
 
     render(<OverviewTab metadata={metadataWithoutRawSubmittedAt} />);
@@ -240,7 +219,6 @@ describe('OverviewTab - Time and Link Logic', () => {
   it('updates weekBefore state correctly when time is valid', async () => {
     const mockWeekBefore = '2025-06-03T09:00:00Z';
 
-    mockGetOneMonthAgo.mockReturnValue('2025-05-10T00:00:00Z');
     mockGetAWeekBeforeSubmittedTime.mockReturnValue(mockWeekBefore);
 
     render(<OverviewTab metadata={completeMetadata} />);
@@ -254,7 +232,6 @@ describe('OverviewTab - Time and Link Logic', () => {
   });
 
   it('updates weekBefore state correctly when time is invalid', async () => {
-    mockGetOneMonthAgo.mockReturnValue('2025-05-10T00:00:00Z');
     mockGetAWeekBeforeSubmittedTime.mockReturnValue(null);
 
     render(<OverviewTab metadata={completeMetadata} />);

--- a/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
@@ -143,7 +143,7 @@ describe('applyTimeFrameRules', () => {
     expect(notification).toBeNull();
   });
 
-  test('should return a warning if "From" date is after "To" date and adjust "To" date one minute after the "From" date when isRelativeToNow prop is false', () => {
+  test('should return an error if "From" date is after "To" date', () => {
     const fromDate = new Date('2025-08-15T10:00:00.000Z');
     const toDate = new Date('2025-08-14T10:00:00.000Z');
     const { correctedFrom, correctedTo, notification } = applyTimeFrameRules(
@@ -153,12 +153,12 @@ describe('applyTimeFrameRules', () => {
       mockTranslator
     );
 
-    expect(notification?.kind).toEqual('warning');
-    expect(notification?.text).toEqual('toBeforeFromAutoAdjust');
+    expect(notification?.kind).toEqual('error');
+    expect(notification?.text).toEqual('toBeforeFromErrorMessage');
 
-    // Ensure 'To' date is adjusted to be one minute after 'From' date
+    // Ensure 'To' and 'From' dates are not changed
     expect(correctedFrom).toEqual(fromDate);
-    expect(correctedTo).toEqual(new Date(fromDate.getTime() + 60 * 1000));
+    expect(correctedTo).toEqual(toDate);
   });
 
   test('should return a warning if "From" date is after the current time when isRelativeToNow prop is true', () => {
@@ -187,312 +187,291 @@ describe('applyTimeFrameRules', () => {
     expect(notification).toBeNull();
   });
 
-  test('should return a warning and cap the "To" date if it exceeds the 3-month max range', () => {
-    jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
-
-    const fromDate = new Date('2025-05-15T10:00:00.000Z');
-    const toDate = new Date('2025-08-16T10:00:00.000Z');
-    const { correctedTo, notification } = applyTimeFrameRules(
-      fromDate,
-      toDate,
-      false,
-      mockTranslator
-    );
-
-    expect(notification?.kind).toEqual('warning');
-    expect(notification?.text).toContain('Date range cannot exceed 3 months');
-
-    const maxToDate = addMonths(fromDate, 3);
-    expect(correctedTo.toISOString()).toEqual(maxToDate.toISOString());
-  });
-});
-
-describe('calculateSynchronizedState', () => {
-  test('should correctly calculate a duration of excactly 1 day', () => {
-    const fromDate = new Date('2025-08-15T10:00:00.000Z');
-    const toDate = new Date('2025-08-16T10:00:00.000Z');
-    const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
-      fromDate,
-      toDate,
-      timezone
-    );
-
-    expect(durationDays).toBe(1);
-    expect(durationHours).toBe(0);
-    expect(durationMinutes).toBe(0);
-  });
-
-  test('should correctly calculate a complex duration of 2 days, 5 hours and 15 minutes', () => {
-    const fromDate = new Date('2025-08-15T10:00:00.000Z');
-    const toDate = new Date('2025-08-17T15:15:00.000Z');
-    const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
-      fromDate,
-      toDate,
-      timezone
-    );
-
-    expect(durationDays).toBe(2);
-    expect(durationHours).toBe(5);
-    expect(durationMinutes).toBe(15);
-  });
-
-  test('should handle a zero duration when "From" and "To" dates are the same', () => {
-    const sameDate = new Date('2025-08-15T10:00:00.000Z');
-    const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
-      sameDate,
-      sameDate,
-      timezone
-    );
-
-    expect(durationDays).toBe(0);
-    expect(durationHours).toBe(0);
-    expect(durationMinutes).toBe(0);
-  });
-
-  test('should handle a negative duration by returning zero values', () => {
-    const fromDate = new Date('2025-08-15T10:00:00.000Z');
-    const toDate = new Date('2025-08-14T10:00:00.000Z'); // One day before
-    const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
-      fromDate,
-      toDate,
-      timezone
-    );
-
-    expect(durationDays).toBe(0);
-    expect(durationHours).toBe(0);
-    expect(durationMinutes).toBe(0);
-  });
-
-  test('should handle a duration of less than a minute', () => {
-    const fromDate = new Date('2025-08-15T10:00:00.000Z');
-    const toDate = new Date('2025-08-15T10:00:30.000Z'); // 30 seconds later
-    const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
-      fromDate,
-      toDate,
-      timezone
-    );
-
-    expect(durationDays).toBe(0);
-    expect(durationHours).toBe(0);
-    expect(durationMinutes).toBe(0);
-  });
-
-  test('should correctly extract time parts for "From" and "To" dates', () => {
-    const fromDate = new Date('2025-08-15T10:30:00.000Z');
-    const toDate = new Date('2025-08-15T12:45:00.000Z');
-    const { fromTime, fromAmPm, toTime, toAmPm } = calculateSynchronizedState(
-      fromDate,
-      toDate,
-      timezone
-    );
-
-    expect(fromTime).toBe('10:30');
-    expect(fromAmPm).toBe('AM');
-    expect(toTime).toBe('12:45');
-    expect(toAmPm).toBe('PM');
-  });
-});
-
-describe('TimeFrameContent Tests', () => {
-  const MOCK_NOW = new Date('2025-08-20T12:00:00.000Z');
-
-  beforeEach(() => {
-    // Reset mocks and timers before each test
-    jest.useFakeTimers();
-    jest.setSystemTime(MOCK_NOW);
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
-  const mockValues: TimeFrameValues = {
-    fromDate: new Date(MOCK_NOW.getTime() - DAY_MS), // 1 day before
-    toDate: MOCK_NOW,
-    durationDays: 1,
-    durationHours: 0,
-    durationMinutes: 0,
-    fromTime: '12:00',
-    fromAmPm: 'PM',
-    toTime: '12:00',
-    toAmPm: 'PM',
-  };
-
-  const mockSetValues = jest.fn();
-
-  test('should render correctly and initialize its state from defaults', () => {
-    render(<TimeFrameContent values={mockValues} setValues={mockSetValues} />);
-
-    const expectedToDate = MOCK_NOW;
-    const expectedFromDate = new Date(expectedToDate.getTime() - DAY_MS); // 1 day before
-
-    expect(screen.getByLabelText('To Date')).toHaveValue(
-      expectedToDate.toLocaleDateString('en-US')
-    );
-    expect(screen.getByLabelText('From Date')).toHaveValue(
-      expectedFromDate.toLocaleDateString('en-US')
-    );
-
-    expect(screen.getByLabelText('Days')).toHaveValue(1);
-    expect(screen.getByLabelText('Hours')).toHaveValue(0);
-  });
-
-  test('should initialize state from props if they exists', () => {
-    render(<TimeFrameContent values={{ ...mockValues }} setValues={mockSetValues} />);
-
-    expect(screen.getByLabelText('From Date')).toHaveValue(
-      mockValues.fromDate.toLocaleDateString('en-US')
-    );
-    expect(screen.getByLabelText('To Date')).toHaveValue(
-      mockValues.toDate.toLocaleDateString('en-US')
-    );
-    expect(screen.getByLabelText('Days')).toHaveValue(mockValues.durationDays);
-    expect(screen.getByLabelText('Hours')).toHaveValue(mockValues.durationHours);
-  });
-
-  test('should update the `From` date when the duration is increased', async () => {
-    const TestWrapper = () => {
-      const [values, setValues] = useState<TimeFrameValues>(() => {
-        const initialFromDate = new Date('2025-08-15T00:00:00.000Z');
-        const initialToDate = new Date(initialFromDate.getTime() + DAY_MS);
-
-        return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
-      });
-
-      return <TimeFrameContent values={values} setValues={setValues} />;
-    };
-
-    render(<TestWrapper />);
-
-    const daysInput = screen.getByLabelText('Days');
-    const toDateInput = screen.getByLabelText('To Date');
-    const fromDateInput = screen.getByLabelText('From Date');
-
-    // Initial state check
-    expect(daysInput).toHaveValue(1);
-    // Use timeZone: 'UTC' to prevent off-by-one day errors in test environments
-    expect(toDateInput).toHaveValue(
-      new Date('2025-08-16T00:00:00.000Z').toLocaleDateString('en-US', { timeZone: 'UTC' })
-    );
-
-    // Act: Change the duration to 3 days
-    fireEvent.change(daysInput, { target: { value: 3 } });
-
-    // Assert: 'To' date is not changed
-    expect(toDateInput).toHaveValue(
-      new Date('2025-08-16T00:00:00.000Z').toLocaleDateString('en-US', { timeZone: 'UTC' })
-    );
-
-    // Assert: Wait for the re-render and check the new values
-    await waitFor(() => {
-      expect(daysInput).toHaveValue(3);
-      const expectedFromDate = new Date('2025-08-13T00:00:00.000Z');
-      expect(fromDateInput).toHaveValue(
-        expectedFromDate.toLocaleDateString('en-US', { timeZone: 'UTC' })
+  describe('calculateSynchronizedState', () => {
+    test('should correctly calculate a duration of excactly 1 day', () => {
+      const fromDate = new Date('2025-08-15T10:00:00.000Z');
+      const toDate = new Date('2025-08-16T10:00:00.000Z');
+      const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
+        fromDate,
+        toDate,
+        timezone
       );
+
+      expect(durationDays).toBe(1);
+      expect(durationHours).toBe(0);
+      expect(durationMinutes).toBe(0);
+    });
+
+    test('should correctly calculate a complex duration of 2 days, 5 hours and 15 minutes', () => {
+      const fromDate = new Date('2025-08-15T10:00:00.000Z');
+      const toDate = new Date('2025-08-17T15:15:00.000Z');
+      const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
+        fromDate,
+        toDate,
+        timezone
+      );
+
+      expect(durationDays).toBe(2);
+      expect(durationHours).toBe(5);
+      expect(durationMinutes).toBe(15);
+    });
+
+    test('should handle a zero duration when "From" and "To" dates are the same', () => {
+      const sameDate = new Date('2025-08-15T10:00:00.000Z');
+      const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
+        sameDate,
+        sameDate,
+        timezone
+      );
+
+      expect(durationDays).toBe(0);
+      expect(durationHours).toBe(0);
+      expect(durationMinutes).toBe(0);
+    });
+
+    test('should handle a negative duration by returning zero values', () => {
+      const fromDate = new Date('2025-08-15T10:00:00.000Z');
+      const toDate = new Date('2025-08-14T10:00:00.000Z'); // One day before
+      const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
+        fromDate,
+        toDate,
+        timezone
+      );
+
+      expect(durationDays).toBe(0);
+      expect(durationHours).toBe(0);
+      expect(durationMinutes).toBe(0);
+    });
+
+    test('should handle a duration of less than a minute', () => {
+      const fromDate = new Date('2025-08-15T10:00:00.000Z');
+      const toDate = new Date('2025-08-15T10:00:30.000Z'); // 30 seconds later
+      const { durationDays, durationHours, durationMinutes } = calculateSynchronizedState(
+        fromDate,
+        toDate,
+        timezone
+      );
+
+      expect(durationDays).toBe(0);
+      expect(durationHours).toBe(0);
+      expect(durationMinutes).toBe(0);
+    });
+
+    test('should correctly extract time parts for "From" and "To" dates', () => {
+      const fromDate = new Date('2025-08-15T10:30:00.000Z');
+      const toDate = new Date('2025-08-15T12:45:00.000Z');
+      const { fromTime, fromAmPm, toTime, toAmPm } = calculateSynchronizedState(
+        fromDate,
+        toDate,
+        timezone
+      );
+
+      expect(fromTime).toBe('10:30');
+      expect(fromAmPm).toBe('AM');
+      expect(toTime).toBe('12:45');
+      expect(toAmPm).toBe('PM');
     });
   });
 
-  test('should update the duration when the `To` date or `From` date is changed', async () => {
-    const TestWrapper = () => {
-      const [values, setValues] = useState<TimeFrameValues>(() => {
-        const initialFromDate = new Date('2025-08-15T00:00:00.000Z');
-        const initialToDate = new Date(initialFromDate.getTime() + DAY_MS);
+  describe('TimeFrameContent Tests', () => {
+    const MOCK_NOW = new Date('2025-08-20T12:00:00.000Z');
 
-        return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
-      });
-
-      return <TimeFrameContent values={values} setValues={setValues} />;
-    };
-
-    render(<TestWrapper />);
-
-    const fromDateInput = screen.getByLabelText('From Date');
-    const toDateInput = screen.getByLabelText('To Date');
-    const daysInput = screen.getByLabelText('Days');
-
-    fireEvent.change(fromDateInput, { target: { value: '2025-08-12' } });
-    fireEvent.change(toDateInput, { target: { value: '2025-08-15' } });
-
-    expect(daysInput).toHaveValue(3); // Default duration is 1 day
-
-    // Change the to date to 2 days later
-    fireEvent.change(toDateInput, { target: { value: '2025-08-17' } });
-    await waitFor(() => {
-      expect(daysInput).toHaveValue(5);
+    beforeEach(() => {
+      // Reset mocks and timers before each test
+      jest.useFakeTimers();
+      jest.setSystemTime(MOCK_NOW);
     });
 
-    // Change the from date to 1 day later
-    fireEvent.change(fromDateInput, { target: { value: '2025-08-13' } });
-    await waitFor(() => {
-      expect(daysInput).toHaveValue(4);
+    afterEach(() => {
+      jest.useRealTimers();
     });
-  });
 
-  test('should display a warning and update state of the "To" date to be after the "From" date by one minute, if the date range becomes inverted', async () => {
-    const initialFrom = '2025-08-10T12:00:00.000Z';
-    const initialTo = '2025-08-12T12:00:00.000Z';
-
-    const TestWrapper = () => {
-      const [values, setValues] = useState<TimeFrameValues>(() => {
-        const initialFromDate = new Date(initialFrom);
-        const initialToDate = new Date(initialTo);
-
-        return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
-      });
-
-      return <TimeFrameContent values={values} setValues={setValues} />;
+    const mockValues: TimeFrameValues = {
+      fromDate: new Date(MOCK_NOW.getTime() - DAY_MS), // 1 day before
+      toDate: MOCK_NOW,
+      durationDays: 1,
+      durationHours: 0,
+      durationMinutes: 0,
+      fromTime: '12:00',
+      fromAmPm: 'PM',
+      toTime: '12:00',
+      toAmPm: 'PM',
     };
 
-    render(<TestWrapper />);
+    const mockSetValues = jest.fn();
 
-    const fromDateInput = screen.getByLabelText('From Date');
-    const toDateInput = screen.getByLabelText('To Date');
-    const daysInput = screen.getByLabelText('Days');
-    const minutesInput = screen.getByLabelText('Minutes');
+    test('should render correctly and initialize its state from defaults', () => {
+      render(<TimeFrameContent values={mockValues} setValues={mockSetValues} />);
 
-    // Change "From" date to be after "To" date
-    const newFromDate = '2025-08-15T12:00:00.000Z';
-    fireEvent.change(fromDateInput, { target: { value: '08/15/2025' } });
+      const expectedToDate = MOCK_NOW;
+      const expectedFromDate = new Date(expectedToDate.getTime() - DAY_MS); // 1 day before
 
-    // Check that the warning notification is displayed
-    const warningNotification = await screen.findByText('toBeforeFromAutoAdjust');
-    expect(warningNotification).toBeInTheDocument();
+      expect(screen.getByLabelText('To Date')).toHaveValue(
+        expectedToDate.toLocaleDateString('en-US')
+      );
+      expect(screen.getByLabelText('From Date')).toHaveValue(
+        expectedFromDate.toLocaleDateString('en-US')
+      );
 
-    // Ensure the To date is adjusted to be after the From date by one minute
-    expect(toDateInput).toHaveValue(
-      new Date(new Date(newFromDate).getTime() + 60 * 1000).toLocaleDateString('en-US')
-    );
-    expect(daysInput).toHaveValue(0);
-    expect(minutesInput).toHaveValue(1);
-  });
+      expect(screen.getByLabelText('Days')).toHaveValue(1);
+      expect(screen.getByLabelText('Hours')).toHaveValue(0);
+    });
 
-  test('To Date should jump to the current time when Now is selected', async () => {
-    const initialFrom = '2025-08-10T12:00:00.000Z';
-    const initialTo = '2025-08-13T12:00:00.000Z';
+    test('should initialize state from props if they exists', () => {
+      render(<TimeFrameContent values={{ ...mockValues }} setValues={mockSetValues} />);
 
-    const TestWrapper = () => {
-      const [values, setValues] = useState<TimeFrameValues>(() => {
-        const initialFromDate = new Date(initialFrom);
-        const initialToDate = new Date(initialTo);
+      expect(screen.getByLabelText('From Date')).toHaveValue(
+        mockValues.fromDate.toLocaleDateString('en-US')
+      );
+      expect(screen.getByLabelText('To Date')).toHaveValue(
+        mockValues.toDate.toLocaleDateString('en-US')
+      );
+      expect(screen.getByLabelText('Days')).toHaveValue(mockValues.durationDays);
+      expect(screen.getByLabelText('Hours')).toHaveValue(mockValues.durationHours);
+    });
 
-        return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
+    test('should update the `From` date when the duration is increased', async () => {
+      const TestWrapper = () => {
+        const [values, setValues] = useState<TimeFrameValues>(() => {
+          const initialFromDate = new Date('2025-08-15T00:00:00.000Z');
+          const initialToDate = new Date(initialFromDate.getTime() + DAY_MS);
+
+          return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
+        });
+
+        return <TimeFrameContent values={values} setValues={setValues} />;
+      };
+
+      render(<TestWrapper />);
+
+      const daysInput = screen.getByLabelText('Days');
+      const toDateInput = screen.getByLabelText('To Date');
+      const fromDateInput = screen.getByLabelText('From Date');
+
+      // Initial state check
+      expect(daysInput).toHaveValue(1);
+      // Use timeZone: 'UTC' to prevent off-by-one day errors in test environments
+      expect(toDateInput).toHaveValue(
+        new Date('2025-08-16T00:00:00.000Z').toLocaleDateString('en-US', { timeZone: 'UTC' })
+      );
+
+      // Act: Change the duration to 3 days
+      fireEvent.change(daysInput, { target: { value: 3 } });
+
+      // Assert: 'To' date is not changed
+      expect(toDateInput).toHaveValue(
+        new Date('2025-08-16T00:00:00.000Z').toLocaleDateString('en-US', { timeZone: 'UTC' })
+      );
+
+      // Assert: Wait for the re-render and check the new values
+      await waitFor(() => {
+        expect(daysInput).toHaveValue(3);
+        const expectedFromDate = new Date('2025-08-13T00:00:00.000Z');
+        expect(fromDateInput).toHaveValue(
+          expectedFromDate.toLocaleDateString('en-US', { timeZone: 'UTC' })
+        );
+      });
+    });
+
+    test('should update the duration when the `To` date or `From` date is changed', async () => {
+      const TestWrapper = () => {
+        const [values, setValues] = useState<TimeFrameValues>(() => {
+          const initialFromDate = new Date('2025-08-15T00:00:00.000Z');
+          const initialToDate = new Date(initialFromDate.getTime() + DAY_MS);
+
+          return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
+        });
+
+        return <TimeFrameContent values={values} setValues={setValues} />;
+      };
+
+      render(<TestWrapper />);
+
+      const fromDateInput = screen.getByLabelText('From Date');
+      const toDateInput = screen.getByLabelText('To Date');
+      const daysInput = screen.getByLabelText('Days');
+
+      fireEvent.change(fromDateInput, { target: { value: '2025-08-12' } });
+      fireEvent.change(toDateInput, { target: { value: '2025-08-15' } });
+
+      expect(daysInput).toHaveValue(3); // Default duration is 1 day
+
+      // Change the to date to 2 days later
+      fireEvent.change(toDateInput, { target: { value: '2025-08-17' } });
+      await waitFor(() => {
+        expect(daysInput).toHaveValue(5);
       });
 
-      return <TimeFrameContent values={values} setValues={setValues} />;
-    };
+      // Change the from date to 1 day later
+      fireEvent.change(fromDateInput, { target: { value: '2025-08-13' } });
+      await waitFor(() => {
+        expect(daysInput).toHaveValue(4);
+      });
+    });
 
-    render(<TestWrapper />);
-    const toDateInput = screen.getByLabelText('To Date');
-    const nowRadio = screen.getByLabelText('Now');
-    // Check the initial value before the click
-    expect(toDateInput).toHaveValue(new Date(initialTo).toLocaleDateString('en-US'));
+    test('should display an error when "From" date exceeds "To" date and dates should not change', async () => {
+      const initialFrom = '2025-08-10T12:00:00.000Z';
+      const initialTo = '2025-08-12T12:00:00.000Z';
 
-    // Act: Click the radio button
-    fireEvent.click(nowRadio);
+      const TestWrapper = () => {
+        const [values, setValues] = useState<TimeFrameValues>(() => {
+          const initialFromDate = new Date(initialFrom);
+          const initialToDate = new Date(initialTo);
 
-    await waitFor(() => {
-      expect(toDateInput).toHaveValue(MOCK_NOW.toLocaleDateString('en-US'));
+          return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
+        });
+
+        return <TimeFrameContent values={values} setValues={setValues} />;
+      };
+
+      render(<TestWrapper />);
+
+      const fromDateInput = screen.getByLabelText('From Date');
+      const toDateInput = screen.getByLabelText('To Date');
+      const daysInput = screen.getByLabelText('Days');
+      const minutesInput = screen.getByLabelText('Minutes');
+
+      // Change "From" date to be after "To" date
+      fireEvent.change(fromDateInput, { target: { value: '08/15/2025' } });
+
+      // Check that the error notification is displayed
+      const errorNotification = await screen.findByText('toBeforeFromErrorMessage');
+      expect(errorNotification).toBeInTheDocument();
+
+      // Ensure the To and From dates are not changed
+      expect(toDateInput).toHaveValue(new Date(initialTo).toLocaleDateString('en-US'));
+      expect(fromDateInput).toHaveValue(new Date(initialFrom).toLocaleDateString('en-US'));
+      expect(daysInput).toHaveValue(2);
+      expect(minutesInput).toHaveValue(0);
+    });
+
+    test('To Date should jump to the current time when Now is selected', async () => {
+      const initialFrom = '2025-08-10T12:00:00.000Z';
+      const initialTo = '2025-08-13T12:00:00.000Z';
+
+      const TestWrapper = () => {
+        const [values, setValues] = useState<TimeFrameValues>(() => {
+          const initialFromDate = new Date(initialFrom);
+          const initialToDate = new Date(initialTo);
+
+          return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
+        });
+
+        return <TimeFrameContent values={values} setValues={setValues} />;
+      };
+
+      render(<TestWrapper />);
+      const toDateInput = screen.getByLabelText('To Date');
+      const nowRadio = screen.getByLabelText('Now');
+      // Check the initial value before the click
+      expect(toDateInput).toHaveValue(new Date(initialTo).toLocaleDateString('en-US'));
+
+      // Act: Click the radio button
+      fireEvent.click(nowRadio);
+
+      await waitFor(() => {
+        expect(toDateInput).toHaveValue(MOCK_NOW.toLocaleDateString('en-US'));
+      });
     });
   });
 });

--- a/galasa-ui/src/utils/functions/timeFrameText.ts
+++ b/galasa-ui/src/utils/functions/timeFrameText.ts
@@ -19,10 +19,6 @@ import { runStructure } from '@/utils/interfaces';
  */
 export const getTimeframeText = (
   runsList: runStructure[],
-  isRelativeToNow: boolean = false,
-  durationDays: number = 0,
-  durationHours: number = 0,
-  durationMinutes: number = 0,
   translations: any,
   formatDate: (date: Date) => string
 ): string => {
@@ -32,27 +28,19 @@ export const getTimeframeText = (
 
   let text = translations('timeFrameText.default');
 
-  if (isRelativeToNow) {
-    text = translations('timeFrameText.isRelativeToNow', {
-      days: durationDays || 0,
-      hours: durationHours || 0,
-      minutes: durationMinutes || 0,
-    });
-  } else {
-    // Filter out any runs that don't have a valid `submittedAt` date
-    const runsWithDates = runsList.filter((run) => run.submittedAt);
+  // Filter out any runs that don't have a valid `submittedAt` date
+  const runsWithDates = runsList.filter((run) => run.submittedAt);
 
-    if (runsWithDates.length !== 0) {
-      const dates = runsWithDates.map((run) => new Date(run.submittedAt).getTime());
-      const earliestDate = new Date(Math.min(...dates));
-      const latestDate = new Date(Math.max(...dates));
+  if (runsWithDates.length !== 0) {
+    const dates = runsWithDates.map((run) => new Date(run.submittedAt).getTime());
+    const earliestDate = new Date(Math.min(...dates));
+    const latestDate = new Date(Math.max(...dates));
 
-      if (earliestDate && latestDate) {
-        text = translations('timeFrameText.range', {
-          from: formatDate(earliestDate),
-          to: formatDate(latestDate),
-        });
-      }
+    if (earliestDate && latestDate) {
+      text = translations('timeFrameText.range', {
+        from: formatDate(earliestDate),
+        to: formatDate(latestDate),
+      });
     }
   }
 


### PR DESCRIPTION
## Why?
Addresses [Slack discussion](https://openmainframeproject.slack.com/archives/C05TCCQDE65/p1755072405090689) regarding improvements to test run time display and link generation logic.
## Changes
- Removed the “max months” rule
- Removed automatic adjustment of the “To” date when it is earlier than the “From” date.
- Updated display to show explicit “From” and “To” dates instead of relative times.
- Updated recent runs link logic to fetch runs of the same test from the last two months.
