### PR TITLE
Compact Language Selector

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -13,7 +13,7 @@
     "logout": "Abmelden"
   },
   "LanguageSelector": {
-    "label": "Sprache"
+    "tooltip": "Sprache auswählen"
   },
   "ThemeSelector": {
     "label": "Thema"
@@ -369,7 +369,7 @@
       "tableDesign": "Tabellendesign",
       "searchCriteria": "Suchkriterien",
       "results": "Ergebnisse",
-      "graphs": "Diagramme"
+      "graph": "Diagramme"
     },
     "content": {
       "timeframe": "Diese Seite befindet sich im Aufbau. Derzeit werden alle Ergebnisse der letzten 24 Stunden angezeigt.",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -13,7 +13,7 @@
     "logout": "Log out"
   },
   "LanguageSelector": {
-    "label": "Language"
+    "tooltip": "Selected language"
   },
   "ThemeSelector": {
     "label": "Theme"

--- a/galasa-ui/src/components/headers/LanguageSelector.tsx
+++ b/galasa-ui/src/components/headers/LanguageSelector.tsx
@@ -7,12 +7,14 @@
 'use client';
 
 import React, { useState, useTransition } from 'react';
-import { Dropdown } from '@carbon/react';
+import { OverflowMenu, OverflowMenuItem, Theme } from '@carbon/react';
 import { setUserLocale } from '@/utils/locale';
-import styles from '@/styles/headers/Selector.module.css';
 import { useLocale, useTranslations } from 'next-intl';
 import { Locale } from '@/i18n/config';
 import { useRouter } from 'next/navigation';
+import { Wikis, Checkmark } from '@carbon/icons-react';
+import styles from '@/styles/headers/Selector.module.css';
+import { useTheme } from '@/contexts/ThemeContext';
 
 const languages = [
   { id: 'en', text: 'English', value: 'en' },
@@ -20,6 +22,8 @@ const languages = [
 ];
 
 export default function LanguageSelector() {
+  
+  const { theme } = useTheme();
   const locale = useLocale();
   const [selectedLanguage, setSelectedLanguage] = useState(
     languages.find((lang) => lang.value === locale) || languages[0]
@@ -44,22 +48,49 @@ export default function LanguageSelector() {
     });
   };
 
+  let current: 'g10' | 'g90';
+  if (theme === 'light') {
+    current = 'g10';
+  } else if (theme === 'dark') {
+    current = 'g90';
+  } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+    current = 'g90';
+  } else {
+    current = 'g10';
+  }
+
   return (
-    <div className={styles.container}>
-      <span className={styles.icon}>{translations('label')} :</span>
-      <Dropdown
-        id="language-selector"
-        items={languages}
-        onChange={handleLanguageChange}
-        selectedItem={selectedLanguage}
-        label="Select language"
-        itemToString={(item: { id: string; text: string; value: string } | null) =>
-          item?.text || ''
-        }
-        size="sm"
-        className={styles.dropdown}
-        disabled={isPending}
-      />
+    <div data-floating-menu-container>
+      <Theme theme={current}>
+        <OverflowMenu
+          className={styles.overflowMenu}
+          focusTrap={true}
+          align="bottom"
+          flipped
+          renderIcon={() => <Wikis style={{ fill: 'white' }} />}
+          size="lg"
+          iconDescription={`${translations('tooltip')} : ${selectedLanguage.text}`}
+          aria-label="Filter menu"
+          tooltipAlignment="center"
+          tooltipPosition="bottom"
+        >
+          {languages.map((language) => (
+            <OverflowMenuItem
+              key={language.id}
+              className={styles.overflowMenuItem}
+              itemText={
+                <div className={styles.overflowMenuItemText}>
+                  <span className={styles.languageText}>{language.text}</span>
+                  {selectedLanguage.id === language.id && (
+                    <Checkmark size={16} className={styles.checkmark} />
+                  )}
+                </div>
+              }
+              onClick={() => handleLanguageChange({ selectedItem: language })}
+            />
+          ))}
+        </OverflowMenu>
+      </Theme>
     </div>
   );
 }

--- a/galasa-ui/src/components/headers/LanguageSelector.tsx
+++ b/galasa-ui/src/components/headers/LanguageSelector.tsx
@@ -22,7 +22,6 @@ const languages = [
 ];
 
 export default function LanguageSelector() {
-  
   const { theme } = useTheme();
   const locale = useLocale();
   const [selectedLanguage, setSelectedLanguage] = useState(

--- a/galasa-ui/src/styles/headers/Selector.module.css
+++ b/galasa-ui/src/styles/headers/Selector.module.css
@@ -54,3 +54,26 @@
 .active {
   color: var(--cds-icon-on-color);
 }
+
+.overflowMenu {
+  outline: none !important;
+  box-shadow: none !important;
+  background-color: #262626 !important;
+  color: white !important;
+  border-bottom: #525252 1px solid !important;
+}
+.overflowMenu:hover {
+  background-color: #474747 !important;
+}
+
+.overflowMenuItem {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+.overflowMenuItemText {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}


### PR DESCRIPTION
closes [#2378](https://github.com/galasa-dev/projectmanagement/issues/2378)

### Description 

- This pull request refactors the language selection feature to a more compact and user-friendly design. The previous controls were large and visually obtrusive this change reducing clutter in the toolbar.

---

### Key Changes:

- Replaced the previous `dropdown` based language selector with the `OverflowMenu` component from the Carbon Design System.

- The tooltip now adapts to the active theme, and the language switch button is using the `g100` theme.


### Demo 


https://github.com/user-attachments/assets/a6c802a0-9fbb-4ff9-8fe7-0f4fea55a2ab

