### PR TITLE
Iss2369 - Uplift gradle version used in build workflow to 9.0.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
 
       - name: Generate typescript openapi client using Gradle

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3
         with:
-          gradle-version: 8.9
+          gradle-version: 9.0.0
           cache-disabled: true
 
       - name: Generate typescript openapi client using Gradle


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2369

## Changes

- Uplift Gradle version used in GitHub Actions workflows to 9.0.0 from 8.9.