### PR TITLE
Fixes URL for test run details page 

### DIFF
--- a/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
+++ b/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
@@ -251,9 +251,11 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
       }
     });
 
-    const encodedQuery = encodeStateToUrlParam(params.toString());
-    const newUrl = encodedQuery ? `${pathname}?q=${encodedQuery}` : pathname;
-    router.replace(newUrl, { scroll: false });
+    if (pathname === '/test-runs') {
+      const encodedQuery = encodeStateToUrlParam(params.toString());
+      const newUrl = encodedQuery ? `${pathname}?q=${encodedQuery}` : pathname;
+      router.replace(newUrl, { scroll: false });
+    }
   }, [
     selectedVisibleColumns,
     columnsOrder,

--- a/galasa-ui/src/tests/components/test-runs/TestRunsTabs.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsTabs.test.tsx
@@ -103,7 +103,7 @@ jest.mock('next/navigation', () => ({
     replace: mockReplace,
   }),
   useSearchParams: () => mockUseSearchParams(),
-  usePathname: () => '/',
+  usePathname: () => '/test-runs',
 }));
 
 // Mock the useDateTimeFormat context

--- a/galasa-ui/src/tests/contexts/TestRunsQueryParamsContext.test.tsx
+++ b/galasa-ui/src/tests/contexts/TestRunsQueryParamsContext.test.tsx
@@ -28,7 +28,7 @@ jest.mock('next/navigation', () => ({
     replace: mockReplace,
   }),
   useSearchParams: () => mockSearchParams,
-  usePathname: () => '/',
+  usePathname: () => '/test-runs',
 }));
 
 // Mock contexts


### PR DESCRIPTION
Ensures link for the run details page has the current tab in URL, and discards unnecessary uncoded q value