### PR TITLE
scrollbar on run log now changes based on theme

### DIFF
--- a/galasa-ui/src/styles/global.scss
+++ b/galasa-ui/src/styles/global.scss
@@ -89,3 +89,47 @@ $spaceSizes: (1, 2, 3, 5, 8, 13);
     margin-top: #{$space}rem;
   }
 }
+
+//--------------------------------------------------------------------------
+// Theme-sensitive scrollbar styling
+//--------------------------------------------------------------------------
+
+/* Default scrollbar styling (light theme) */
+:root {
+  --scrollbar-track: #f4f4f4;
+  --scrollbar-thumb: #c6c6c6;
+  --scrollbar-thumb-hover: #a8a8a8;
+}
+
+/* Dark theme scrollbar styling */
+[data-carbon-theme='dark'] {
+  --scrollbar-track: #393939; /* gray-80 equivalent */
+  --scrollbar-thumb: #6f6f6f; /* gray-60 equivalent */
+  --scrollbar-thumb-hover: #8d8d8d; /* gray-50 equivalent */
+}
+
+/* Apply scrollbar styling to all elements */
+* {
+  /* Firefox */
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+}
+
+/* WebKit/Blink browsers (Chrome, Safari, Edge) */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--scrollbar-track);
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: var(--scrollbar-thumb);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: var(--scrollbar-thumb-hover);
+}

--- a/galasa-ui/src/styles/test-runs/test-run-details/LogTab.module.css
+++ b/galasa-ui/src/styles/test-runs/test-run-details/LogTab.module.css
@@ -84,6 +84,24 @@
   overflow-y: auto;
 }
 
+/* Scrollbar styling for light/dark theme compatibility */
+.runLog::-webkit-scrollbar {
+  width: 10px;
+}
+
+.runLog::-webkit-scrollbar-track {
+  background: var(--cds-background, #f1f1f1);
+}
+
+.runLog::-webkit-scrollbar-thumb {
+  background: var(--cds-border-subtle, #c6c6c6);
+  border-radius: 4px;
+}
+
+.runLog::-webkit-scrollbar-thumb:hover {
+  background: var(--cds-border-strong, #8d8d8d);
+}
+
 .runLogContent {
   width: 100%;
 }

--- a/galasa-ui/src/styles/test-runs/test-run-details/LogTab.module.css
+++ b/galasa-ui/src/styles/test-runs/test-run-details/LogTab.module.css
@@ -84,23 +84,6 @@
   overflow-y: auto;
 }
 
-/* Scrollbar styling for light/dark theme compatibility */
-.runLog::-webkit-scrollbar {
-  width: 10px;
-}
-
-.runLog::-webkit-scrollbar-track {
-  background: var(--cds-background, #f1f1f1);
-}
-
-.runLog::-webkit-scrollbar-thumb {
-  background: var(--cds-border-subtle, #c6c6c6);
-  border-radius: 4px;
-}
-
-.runLog::-webkit-scrollbar-thumb:hover {
-  background: var(--cds-border-strong, #8d8d8d);
-}
 
 .runLogContent {
   width: 100%;


### PR DESCRIPTION
Signed-off-by: techcobweb <77053+techcobweb@users.noreply.github.com>

# Why ?
See issue [Web UI: Run log scroll bar isn't changing theme light/dark mode. #2431](https://github.com/galasa-dev/projectmanagement/issues/2431)

Scroll bar now looks like this in dark mode:

https://github.com/user-attachments/assets/6cddfd5f-d8aa-4017-9611-fad8a4775af7

