### PR TITLE
Added ESLint ignores and fix for user role dropdown

### DIFF
--- a/galasa-ui/src/components/mysettings/AccessTokensSection.tsx
+++ b/galasa-ui/src/components/mysettings/AccessTokensSection.tsx
@@ -85,6 +85,9 @@ export default function AccessTokensSection({
     };
 
     loadAccessTokens();
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [accessTokensPromise]);
 
   const translations = useTranslations('AccessTokensSection');

--- a/galasa-ui/src/components/test-runs/graph/TestRunsGraph.tsx
+++ b/galasa-ui/src/components/test-runs/graph/TestRunsGraph.tsx
@@ -191,6 +191,9 @@ export default function TestRunGraph({
       toolbar: { enabled: false },
       experimental: true,
     };
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [headerDefinitions, isLoading, isLightTheme, translations, xTickValues]);
 
   type DataBoundElement = HTMLElement & { __data__?: DataPoint };

--- a/galasa-ui/src/components/test-runs/test-run-details/3270Tab/ScreenshotToolbar.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/3270Tab/ScreenshotToolbar.tsx
@@ -152,6 +152,9 @@ export default function ScreenshotToolbar({
 
       return cleanup;
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [
     is3270CurrentlySelected,
     isLoading,

--- a/galasa-ui/src/components/test-runs/test-run-details/3270Tab/TabFor3270.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/3270Tab/TabFor3270.tsx
@@ -39,6 +39,9 @@ export default function TabFor3270({
     if (is3270CurrentlySelected) {
       handleNavigateTo3270(highlightedRowId);
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [highlightedRowId, is3270CurrentlySelected]);
 
   // Get the 'terminalScreen' parameter
@@ -47,6 +50,9 @@ export default function TabFor3270({
       const url = new URL(window.location.href);
       setHighlightedRowId(url.searchParams.get('terminalScreen') || '');
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [is3270CurrentlySelected]);
 
   if (isError) {

--- a/galasa-ui/src/components/test-runs/test-run-details/3270Tab/TableOfScreenshots.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/3270Tab/TableOfScreenshots.tsx
@@ -138,6 +138,9 @@ export default function TableOfScreenshots({
 
     highlightFirstRowOnPageLoad();
     checkHighlightedRowInFilteredRows();
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [filteredRows, highlightedRowId]);
 
   useMemo(() => {
@@ -165,6 +168,9 @@ export default function TableOfScreenshots({
 
       fetchData();
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, []);
 
   // When highlighted image changes, update image data.
@@ -174,6 +180,9 @@ export default function TableOfScreenshots({
     ) as TerminalImage;
 
     setImageData(newImageData);
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [highlightedRowId, allImageData]);
 
   // Handle previous/ next image buttons.
@@ -202,6 +211,9 @@ export default function TableOfScreenshots({
 
       setMoveImageSelection(0);
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [
     moveImageSelection,
     filteredRows,

--- a/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
@@ -203,6 +203,9 @@ export function ArtifactsTab({
         setZos3270TerminalData
       );
     }
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [artifacts, checkForZosTerminalFolderStructure, is3270ScreenEnabled]);
 
   const createFolderSegments = (

--- a/galasa-ui/src/components/users/UsersTable.tsx
+++ b/galasa-ui/src/components/users/UsersTable.tsx
@@ -161,6 +161,9 @@ export default function UsersTable({ usersListPromise, currentUserPromise }: Use
 
     loadUsers();
     checkForEditUsersPermission();
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, [currentUserPromise, usersListPromise]);
 
   if (isError) {

--- a/galasa-ui/src/contexts/ThemeContext.tsx
+++ b/galasa-ui/src/contexts/ThemeContext.tsx
@@ -43,6 +43,9 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
       setTheme('system');
     }
     setIsLoaded(true);
+
+    // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
+    // eslint-disable-next-line
   }, []);
 
   if (!isLoaded) return null; // Prevent flash by not rendering anything until theme is loaded

--- a/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
+++ b/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
@@ -181,6 +181,8 @@ describe('UserRoleSection', () => {
       setTimeout(() => resolve(dummyRoles), 1000);
     });
 
+    await rolesPromise;
+
     render(
       <UserRoleSection
         userProfilePromise={Promise.resolve(dummyProfile)}


### PR DESCRIPTION
# Why?

Removes clutter from the build-locally script by suppressing the warnings, which have each been reviewed and identified as intentional. Also, the PR fixes the user role dropdown error in the unit tests.