### PR TITLE
James C 3270 Add Cursor Colour Inversion 

### DIFF
--- a/galasa-ui/src/tests/utils/3270/appendCursor.test.ts
+++ b/galasa-ui/src/tests/utils/3270/appendCursor.test.ts
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import '@testing-library/jest-dom';
-import { describe, expect, test } from "@jest/globals";
+import { describe, expect, test } from '@jest/globals';
 import { appendCursor } from '@/utils/3270/appendCursor';
 import { TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
 
-describe("appendCursor", () => {
-  test("should not modify the array when cursorRow or cursorColumn are undefined", () => {
+describe('appendCursor', () => {
+  test('should not modify the array when cursorRow or cursorColumn are undefined', () => {
     const rows = 5;
     const columns = 4;
     const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
@@ -18,12 +18,10 @@ describe("appendCursor", () => {
 
     appendCursor(undefined, undefined, rows, columns, characterArray);
 
-    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
-      Array(columns).fill(null)
-    ));
+    expect(characterArray).toEqual(Array.from({ length: rows }, () => Array(columns).fill(null)));
   });
 
-  test("should set cursor property to true for existing character at (cursorRow, cursorColumn)", () => {
+  test('should set cursor property to true for existing character at (cursorRow, cursorColumn)', () => {
     const rows = 5;
     const columns = 4;
     const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
@@ -32,15 +30,17 @@ describe("appendCursor", () => {
     const cursorRow = 2;
     const cursorColumn = 1;
 
-    const initialChar = { character: "A" };
+    const initialChar = { character: 'A' };
     characterArray[cursorRow][cursorColumn] = initialChar;
 
     appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
 
-    expect(characterArray[cursorRow][cursorColumn]).toEqual(expect.objectContaining({ cursor: true }));
+    expect(characterArray[cursorRow][cursorColumn]).toEqual(
+      expect.objectContaining({ cursor: true })
+    );
   });
 
-  test("should create a new character with cursor: true at (cursorRow, cursorColumn) when no character exists", () => {
+  test('should create a new character with cursor: true at (cursorRow, cursorColumn) when no character exists', () => {
     const rows = 5;
     const columns = 4;
     const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
@@ -51,10 +51,12 @@ describe("appendCursor", () => {
 
     appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
 
-    expect(characterArray[cursorRow][cursorColumn]).toEqual(expect.objectContaining({ character: "", cursor: true }));
+    expect(characterArray[cursorRow][cursorColumn]).toEqual(
+      expect.objectContaining({ character: '', cursor: true })
+    );
   });
 
-  test("should not modify the array when cursorRow or cursorColumn are out of bounds", () => {
+  test('should not modify the array when cursorRow or cursorColumn are out of bounds', () => {
     const rows = 5;
     const columns = 4;
     const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
@@ -65,12 +67,10 @@ describe("appendCursor", () => {
 
     appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
 
-    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
-      Array(columns).fill(null)
-    ));
+    expect(characterArray).toEqual(Array.from({ length: rows }, () => Array(columns).fill(null)));
   });
 
-  test("should not modify the array when cursorRow or cursorColumn are negative", () => {
+  test('should not modify the array when cursorRow or cursorColumn are negative', () => {
     const rows = 5;
     const columns = 4;
     const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
@@ -81,8 +81,6 @@ describe("appendCursor", () => {
 
     appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
 
-    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
-      Array(columns).fill(null)
-    ));
+    expect(characterArray).toEqual(Array.from({ length: rows }, () => Array(columns).fill(null)));
   });
 });

--- a/galasa-ui/src/tests/utils/3270/appendCursor.test.ts
+++ b/galasa-ui/src/tests/utils/3270/appendCursor.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import '@testing-library/jest-dom';
+import { describe, expect, test } from "@jest/globals";
+import { appendCursor } from '@/utils/3270/appendCursor';
+import { TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
+
+describe("appendCursor", () => {
+  test("should not modify the array when cursorRow or cursorColumn are undefined", () => {
+    const rows = 5;
+    const columns = 4;
+    const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    );
+
+    appendCursor(undefined, undefined, rows, columns, characterArray);
+
+    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    ));
+  });
+
+  test("should set cursor property to true for existing character at (cursorRow, cursorColumn)", () => {
+    const rows = 5;
+    const columns = 4;
+    const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    );
+    const cursorRow = 2;
+    const cursorColumn = 1;
+
+    const initialChar = { character: "A" };
+    characterArray[cursorRow][cursorColumn] = initialChar;
+
+    appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
+
+    expect(characterArray[cursorRow][cursorColumn]).toEqual(expect.objectContaining({ cursor: true }));
+  });
+
+  test("should create a new character with cursor: true at (cursorRow, cursorColumn) when no character exists", () => {
+    const rows = 5;
+    const columns = 4;
+    const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    );
+    const cursorRow = 2;
+    const cursorColumn = 1;
+
+    appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
+
+    expect(characterArray[cursorRow][cursorColumn]).toEqual(expect.objectContaining({ character: "", cursor: true }));
+  });
+
+  test("should not modify the array when cursorRow or cursorColumn are out of bounds", () => {
+    const rows = 5;
+    const columns = 4;
+    const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    );
+    const cursorRow = 10;
+    const cursorColumn = 1;
+
+    appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
+
+    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    ));
+  });
+
+  test("should not modify the array when cursorRow or cursorColumn are negative", () => {
+    const rows = 5;
+    const columns = 4;
+    const characterArray: (TerminalImageCharacter | null)[][] = Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    );
+    const cursorRow = -1;
+    const cursorColumn = 1;
+
+    appendCursor(cursorRow, cursorColumn, rows, columns, characterArray);
+
+    expect(characterArray).toEqual(Array.from({ length: rows }, () =>
+      Array(columns).fill(null)
+    ));
+  });
+});

--- a/galasa-ui/src/tests/utils/3270/appendMetadataStatusLine.test.ts
+++ b/galasa-ui/src/tests/utils/3270/appendMetadataStatusLine.test.ts
@@ -5,7 +5,7 @@
  */
 import '@testing-library/jest-dom';
 import { appendMetadataStatusLine } from '@/utils/3270/appendMetadataStatusLine';
-import { TerminalImage, TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
+import { TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
 
 describe('appendMetadataStatusLine', () => {
   const imageDataId = 'testId';

--- a/galasa-ui/src/utils/3270/appendCursor.ts
+++ b/galasa-ui/src/utils/3270/appendCursor.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import { TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
+
+export function appendCursor(
+  cursorRow: number | undefined,
+  cursorColumn: number | undefined,
+  rows: number,
+  columns: number,
+  characterArray: (TerminalImageCharacter | null)[][]
+) {
+  if (cursorRow && cursorColumn) {
+    if (cursorRow < rows && cursorRow >= 0 && cursorColumn < columns && cursorColumn >= 0) {
+      if (characterArray[cursorRow][cursorColumn]) {
+        characterArray[cursorRow][cursorColumn].cursor = true;
+      } else {
+        characterArray[cursorRow][cursorColumn] = { character: '', cursor: true };
+      }
+    }
+  }
+}

--- a/galasa-ui/src/utils/3270/getArrayOfImageCharacters.ts
+++ b/galasa-ui/src/utils/3270/getArrayOfImageCharacters.ts
@@ -6,6 +6,7 @@
 import { TerminalImage, TerminalImageCharacter } from '@/utils/interfaces/3270Terminal';
 import { appendImageDataToCharacterArray } from '@/utils/3270/appendImageDataToCharacterArray';
 import { appendMetadataStatusLine } from '@/utils/3270/appendMetadataStatusLine';
+import { appendCursor } from '@/utils/3270/appendCursor';
 
 // Return a 2D array of characters, with each character representing all properties of its parent TerminalImageField.
 export default function getArrayOfImageCharacters(
@@ -30,21 +31,7 @@ export default function getArrayOfImageCharacters(
     imageData.aid
   );
 
-  // TODO: Append cursor - after the backend is fixed as currently the cursor row and column are the wrong way round.
-
-  // const cursorRow = imageData.cursorRow;
-  // const cursorColumn = imageData.cursorColumn;
-
-  // if (cursorRow && cursorColumn) {
-
-  //   if (cursorRow < rows && cursorColumn < columns) {
-  //     if (characterArray[cursorRow][cursorColumn]) {
-  //       characterArray[cursorRow][cursorColumn].cursor = true;
-  //     } else {
-  //       characterArray[cursorRow][cursorColumn] = { character: '', cursor: true };
-  //     }
-  //   }
-  // }
+  appendCursor(imageData.cursorRow, imageData.cursorColumn, rows, columns, characterArray);
 
   return characterArray;
 }

--- a/galasa-ui/src/utils/3270/screenshotRenderer.ts
+++ b/galasa-ui/src/utils/3270/screenshotRenderer.ts
@@ -68,7 +68,6 @@ function drawCharacters(
         if (characterCell.cursor) {
           // Invert background and foreground
           context.fillStyle = characterColour;
-          console.log(characterWidth);
           context.fillRect(x, y - cellHeight / 2, characterWidth, cellHeight);
           context.fillStyle = backgroundColour;
           context.fillText(characterCell.character, x, y);

--- a/galasa-ui/src/utils/3270/screenshotRenderer.ts
+++ b/galasa-ui/src/utils/3270/screenshotRenderer.ts
@@ -65,7 +65,17 @@ function drawCharacters(
     // Edit context if character cell found.
     row.forEach((characterCell) => {
       if (characterCell) {
-        context.fillText(characterCell.character, x, y);
+        if (characterCell.cursor) {
+          // Invert background and foreground
+          context.fillStyle = characterColour;
+          console.log(characterWidth);
+          context.fillRect(x, y - cellHeight / 2, characterWidth, cellHeight);
+          context.fillStyle = backgroundColour;
+          context.fillText(characterCell.character, x, y);
+          context.fillStyle = characterColour;
+        } else {
+          context.fillText(characterCell.character, x, y);
+        }
 
         // TODO: Extra image fields to be handled here, such as background colour.
       }


### PR DESCRIPTION
# Why?

As the cursor position is not displayed, inverting the colours of the cursor's position seems to be the best way to display its whereabouts.

<img width="664" height="383" alt="image" src="https://github.com/user-attachments/assets/1987bbe0-84b8-44ec-b878-ce87aed45a9a" />

Note: the cursor might actually be in a different place for this specific image as the logic for the backend has not been pushed into main yet