### PR TITLE
Remove 3270 feature flag inital commit

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -31,7 +31,6 @@
     "description": "Früher Zugriff auf neue Funktionen. Diese Funktionen sind experimentell und können sich ändern oder entfernt werden.",
     "features": {
       "testRunSearch": "Testlauf-Suche und Anzeige",
-      "is3270ScreenEnabled": "Unterstützung für das Anzeigen und Herunterladen von 3270-Terminals",
       "graph": "Testlauf-Diagramm"
     }
   },

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -31,7 +31,6 @@
     "description": "Early access to new features. These are experimental and subject to change or removal.",
     "features": {
       "testRunSearch": "Test Run searching and viewing",
-      "is3270ScreenEnabled": "Support for viewing and downloading 3270 terminals",
       "graph": "Test Run Graphs"
     }
   },

--- a/galasa-ui/src/components/mysettings/ExperimentalFeaturesSection.tsx
+++ b/galasa-ui/src/components/mysettings/ExperimentalFeaturesSection.tsx
@@ -21,10 +21,6 @@ export default function ExperimentalFeaturesSection() {
       label: translations(`features.testRunSearch`),
     },
     {
-      key: FEATURE_FLAGS.IS_3270_SCREEN_ENABLED,
-      label: translations('features.is3270ScreenEnabled'),
-    },
-    {
       key: FEATURE_FLAGS.GRAPH,
       label: translations('features.graph'),
     },

--- a/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
@@ -67,9 +67,6 @@ export function ArtifactsTab({
   const ZIP_EXTENSIONS = ['zip', 'gz', 'jar', 'rar', '7z'];
   const IMAGE_EXTENSIONS = ['png', 'jpg', 'jpeg', 'gif', 'svg'];
 
-  const { isFeatureEnabled } = useFeatureFlags();
-  const is3270ScreenEnabled = isFeatureEnabled(FEATURE_FLAGS.IS_3270_SCREEN_ENABLED);
-
   function formatFileSize(bytes: number) {
     let fileSize = '';
 
@@ -195,18 +192,16 @@ export function ArtifactsTab({
 
     setTreeData(root);
 
-    if (is3270ScreenEnabled) {
-      // This checks for the terminal structure, and sets the zosTerminalData hook in TestRunDetails for later use in get3270Screenshots.ts.
-      checkForZosTerminalFolderStructure(
-        root,
-        setZos3270TerminalFolderExists,
-        setZos3270TerminalData
-      );
-    }
+    // This checks for the terminal structure, and sets the zosTerminalData hook in TestRunDetails for later use in get3270Screenshots.ts.
+    checkForZosTerminalFolderStructure(
+      root,
+      setZos3270TerminalFolderExists,
+      setZos3270TerminalData
+    );
 
     // If you're adding extra state to this hook, make sure to review the dependency array due to the warning suppression:
     // eslint-disable-next-line
-  }, [artifacts, checkForZosTerminalFolderStructure, is3270ScreenEnabled]);
+  }, [artifacts, checkForZosTerminalFolderStructure]);
 
   const createFolderSegments = (
     segments: string[],

--- a/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
+++ b/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
@@ -75,7 +75,6 @@ describe('Feature Flags Provider and useFeatureFlags Hook', () => {
 
     const expectedCookieVal = JSON.stringify({
       [FEATURE_FLAGS.TEST_RUNS]: true,
-      [FEATURE_FLAGS.IS_3270_SCREEN_ENABLED]: false,
       [FEATURE_FLAGS.GRAPH]: false,
     });
 

--- a/galasa-ui/src/utils/featureFlags.ts
+++ b/galasa-ui/src/utils/featureFlags.ts
@@ -7,14 +7,12 @@
 // Centralized feature flags
 export const FEATURE_FLAGS = {
   TEST_RUNS: 'testRuns',
-  IS_3270_SCREEN_ENABLED: 'is3270ScreenEnabled',
   GRAPH: 'graph',
   // Add other feature flags here
 } as const;
 
 export const DEFAULT_FEATURE_FLAGS = {
   testRuns: false,
-  is3270ScreenEnabled: false,
   graph: false,
   // Add other feature flags here
 } as const;


### PR DESCRIPTION
Removes the 3270 feature flag. The component is still behind the "test-runs" flag so even if issues occur it is still behind a safety net.