### PR TITLE
James c link to lines goes to method if user previously jumped to a method

### DIFF
--- a/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
@@ -7,7 +7,6 @@
 
 import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { Search, OverflowMenu, Button } from '@carbon/react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import styles from '@/styles/test-runs/test-run-details/LogTab.module.css';
 import { Checkbox } from '@carbon/react';
 import {
@@ -129,9 +128,7 @@ export default function LogTab({ logs, initialLine }: LogTabProps) {
     urlWithoutLines.searchParams.delete('line');
 
     // Construct the permalink
-    console.log("Hello" + urlWithoutLines.toString())
     const permalink = `${urlWithoutLines.toString()}#log-${startLine}-${startOffset}-${endLine}-${endOffset}`;
-    console.log(permalink);
 
     navigator.clipboard.writeText(permalink);
 
@@ -590,9 +587,9 @@ export default function LogTab({ logs, initialLine }: LogTabProps) {
               <span className={styles.matchCounter} data-testid="match-counter">
                 {totalMatches > 0
                   ? translations('matchCounter', {
-                    current: currentMatchIndex + 1,
-                    total: totalMatches,
-                  })
+                      current: currentMatchIndex + 1,
+                      total: totalMatches,
+                    })
                   : translations('noMatches')}
               </span>
               <Button

--- a/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
@@ -7,6 +7,7 @@
 
 import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import { Search, OverflowMenu, Button } from '@carbon/react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import styles from '@/styles/test-runs/test-run-details/LogTab.module.css';
 import { Checkbox } from '@carbon/react';
 import {
@@ -123,7 +124,14 @@ export default function LogTab({ logs, initialLine }: LogTabProps) {
     // Construct the base URL from its parts to explicitly exclude any existing hash
     const baseUrl = window.location.origin + window.location.pathname + window.location.search;
 
-    const permalink = `${baseUrl}#log-${startLine}-${startOffset}-${endLine}-${endOffset}`;
+    // Build the URL without the 'line' parameter
+    const urlWithoutLines = new URL(baseUrl);
+    urlWithoutLines.searchParams.delete('line');
+
+    // Construct the permalink
+    console.log("Hello" + urlWithoutLines.toString())
+    const permalink = `${urlWithoutLines.toString()}#log-${startLine}-${startOffset}-${endLine}-${endOffset}`;
+    console.log(permalink);
 
     navigator.clipboard.writeText(permalink);
 
@@ -582,9 +590,9 @@ export default function LogTab({ logs, initialLine }: LogTabProps) {
               <span className={styles.matchCounter} data-testid="match-counter">
                 {totalMatches > 0
                   ? translations('matchCounter', {
-                      current: currentMatchIndex + 1,
-                      total: totalMatches,
-                    })
+                    current: currentMatchIndex + 1,
+                    total: totalMatches,
+                  })
                   : translations('noMatches')}
               </span>
               <Button

--- a/galasa-ui/src/tests/components/test-runs/test-run-details/LogTab.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/test-run-details/LogTab.test.tsx
@@ -542,6 +542,34 @@ Line with $dollar and ^caret`;
         expect(copyButton).toHaveClass('buttonDisabled');
       });
     });
+
+    it('copies permalink without the line parameter', async () => {
+      const writeTextSpy = jest.spyOn(navigator.clipboard, 'writeText');
+      render(<LogTab logs={sampleLogs} />);
+      await screen.findByText(/Initializing database connection/);
+
+      const startLineNode = screen.getByText(/Initializing database connection/);
+      const endLineNode = screen.getByText(/Connection retry attempt 1/);
+
+      act(() => {
+        // Simulate selection with offsets
+        mockSelection(startLineNode, endLineNode, 5, 10);
+        fireEvent(document, new Event('selectionchange'));
+      });
+
+      const urlAfterInjection = `${window.location.origin}${window.location.pathname}${window.location.search}?line=1${window.location.hash}`;
+
+      window.history.pushState(null, '', urlAfterInjection);
+
+      const copyButton = await screen.findByTestId('icon-button-copy-permalink');
+
+      // Click the button
+      act(() => {
+        fireEvent.click(copyButton);
+      });
+
+      expect(writeTextSpy.mock.calls[0][0]).not.toContain('?line=1');
+    });
   });
 
   describe('URL Hash Handling', () => {


### PR DESCRIPTION
# Why?

Solves 
[#2388](https://github.com/galasa-dev/projectmanagement/issues/2388) by removing `?line=...` parameter from the URL when copying the link to selected lines after selecting a method. See story for more detail.