### PR TITLE
James c saved queries styling changes

### DIFF
--- a/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
@@ -172,18 +172,17 @@ export default function CollapsibleSideBar({ handleEditQueryName }: CollapsibleS
             <div className={styles.innerContentWrapper}>
               <p className={styles.headerTitle}>{translations('savedQueries')}</p>
               <div className={styles.toolbar}>
-                <div id={styles.collapsibleSideNavSearch}>
-                  <Search
-                    labelText={translations('searchSavedQueries')}
-                    placeholder={translations('searchSavedQueries')}
-                    size="lg"
-                    value={searchTerm}
-                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                      setSearchTerm(e.target.value)
-                    }
-                    onClear={() => setSearchTerm('')}
-                  />
-                </div>
+                <Search
+                  className={styles.collapsibleSideNavSearch}
+                  labelText={translations('searchSavedQueries')}
+                  placeholder={translations('searchSavedQueries')}
+                  size="lg"
+                  value={searchTerm}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setSearchTerm(e.target.value)
+                  }
+                  onClear={() => setSearchTerm('')}
+                />
                 <Button
                   kind="ghost"
                   hasIconOnly

--- a/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
@@ -189,6 +189,7 @@ export default function CollapsibleSideBar({ handleEditQueryName }: CollapsibleS
                   iconDescription={translations('addCurrentQuery')}
                   onClick={handleAddCurrentQuery}
                   tooltipPosition="top"
+                  tooltipAlignment="end"
                 />
               </div>
 

--- a/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/CollapsibleSideBar.tsx
@@ -172,16 +172,18 @@ export default function CollapsibleSideBar({ handleEditQueryName }: CollapsibleS
             <div className={styles.innerContentWrapper}>
               <p className={styles.headerTitle}>{translations('savedQueries')}</p>
               <div className={styles.toolbar}>
-                <Search
-                  labelText={translations('searchSavedQueries')}
-                  placeholder={translations('searchSavedQueries')}
-                  size="lg"
-                  value={searchTerm}
-                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                    setSearchTerm(e.target.value)
-                  }
-                  onClear={() => setSearchTerm('')}
-                />
+                <div id={styles.collapsibleSideNavSearch}>
+                  <Search
+                    labelText={translations('searchSavedQueries')}
+                    placeholder={translations('searchSavedQueries')}
+                    size="lg"
+                    value={searchTerm}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setSearchTerm(e.target.value)
+                    }
+                    onClear={() => setSearchTerm('')}
+                  />
+                </div>
                 <Button
                   kind="ghost"
                   hasIconOnly

--- a/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
@@ -217,6 +217,7 @@ export default function QueryItem({
             onClick={action.onClick}
             isDelete={action.isDelete}
             disabled={action.disabled}
+            id={isDefault && action.isDelete ? styles.defaultQueryDeleteButton : undefined}
           />
         ))}
       </OverflowMenu>

--- a/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
@@ -208,7 +208,7 @@ export default function QueryItem({
         iconDescription={translations('actions')}
         flipped
         className={styles.overflowMenu}
-        align="left"
+        align="top"
       >
         {actions.map((action) => (
           <OverflowMenuItem

--- a/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
+++ b/galasa-ui/src/components/test-runs/saved-queries/QueryItem.tsx
@@ -208,7 +208,7 @@ export default function QueryItem({
         iconDescription={translations('actions')}
         flipped
         className={styles.overflowMenu}
-        direction="top"
+        align="left"
       >
         {actions.map((action) => (
           <OverflowMenuItem

--- a/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
+++ b/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
@@ -93,6 +93,6 @@
   z-index: 9999;
 }
 
-#collapsibleSideNavSearch {
+.collapsibleSideNavSearch {
   width: 80%;
 }

--- a/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
+++ b/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
@@ -93,6 +93,6 @@
   z-index: 9999;
 }
 
-#collapsibleSideNavSearch{
+#collapsibleSideNavSearch {
   width: 80%;
 }

--- a/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
+++ b/galasa-ui/src/styles/test-runs/saved-queries/CollapsibleSideBar.module.css
@@ -32,7 +32,7 @@
 }
 
 .sideNavExpanded {
-  width: 320px;
+  width: 330px;
   max-width: 360px;
   background-color: var(--cds-layer);
   border-right: 1px solid var(--cds-border-subtle);
@@ -48,7 +48,7 @@
 }
 
 .innerContentWrapper {
-  width: 320px;
+  width: 330px;
   display: flex;
   flex-direction: column;
   opacity: 0;
@@ -81,8 +81,6 @@
 
 .sideNavContent {
   flex: 1;
-  overflow-y: auto;
-  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -93,4 +91,8 @@
   bottom: 5.5rem;
   right: 1rem;
   z-index: 9999;
+}
+
+#collapsibleSideNavSearch{
+  width: 80%;
 }

--- a/galasa-ui/src/styles/test-runs/saved-queries/QueryItem.module.css
+++ b/galasa-ui/src/styles/test-runs/saved-queries/QueryItem.module.css
@@ -11,7 +11,7 @@
   position: relative;
   transition: background-color 0.15s ease-in-out;
   padding: 0.3rem 0;
-  padding-right: 0.5rem;
+  padding-right: 1.4rem;
 }
 
 .sideNavItem.collapsed {

--- a/galasa-ui/src/styles/test-runs/saved-queries/QueryItem.module.css
+++ b/galasa-ui/src/styles/test-runs/saved-queries/QueryItem.module.css
@@ -76,3 +76,7 @@
 .overflowMenu:hover {
   background-color: var(--cds-layer-selected);
 }
+
+#defaultQueryDeleteButton:hover {
+  color: var(--cds-text-disabled);
+}


### PR DESCRIPTION
# Why?

Solves [#2445](https://github.com/galasa-dev/projectmanagement/issues/2445) with various stying changes (see below). Please note it does **not** seem to be possible to remove the tooltips and that the positions are very restrictive, especially with all custom CSS being overridden.

- Moving the `Add current query` tooltip so that the entire message is  shown <img width="1512" height="777" alt="image" src="https://github.com/user-attachments/assets/fc4900a3-50c0-4e34-b477-4b883a43c059" />
- Shifting the nav bar contents to the left so that the entire tooltip for the overflow menus are visible. <img width="1512" height="771" alt="image" src="https://github.com/user-attachments/assets/fdc8436b-e9ea-4dba-8bbb-91c0074eb970" />
- Delete button no longer has a text colour change on hover <img width="1512" height="824" alt="image" src="https://github.com/user-attachments/assets/fde93321-915b-4cfa-9a2f-86e6f73aa17d" />

