### PR TITLE
Iss2486 - Allow users to open a test run into a new tab

### DIFF
--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -73,7 +73,6 @@ export default function TestRunsTable({
   durationMinutes,
 }: TestRunsTableProps) {
   const translations = useTranslations('TestRunsTable');
-  const { pushBreadCrumb } = useHistoryBreadCrumbs();
   const { formatDate } = useDateTimeFormat();
 
   const router = useRouter();
@@ -131,12 +130,6 @@ export default function TestRunsTable({
 
   // Navigate to the test run details page using the runId
   const handleRowClick = (runId: string, runName: string) => {
-    // Push the current page URL to the breadcrumb history
-    pushBreadCrumb({
-      ...TEST_RUNS,
-      route: `/test-runs?${searchParams.toString()}`,
-    });
-
     // Navigate to the test run details page
     router.push(`/test-runs/${runId}`);
   };

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -40,6 +40,7 @@ import { useDateTimeFormat } from '@/contexts/DateTimeFormatContext';
 import { useDisappearingNotification } from '@/hooks/useDisappearingNotification';
 import { getTimeframeText } from '@/utils/functions/timeFrameText';
 import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
+import Link from 'next/link';
 
 interface CustomCellProps {
   header: string;
@@ -142,7 +143,7 @@ export default function TestRunsTable({
     let cellComponent = (
       <TableCell className={styles.linkCell}>
         {value}
-        <a href={href} className={styles.linkOverlay} />
+        <Link href={href} prefetch={false} className={styles.linkOverlay} />
       </TableCell>
     );
 
@@ -154,7 +155,7 @@ export default function TestRunsTable({
       cellComponent = (
         <TableCell className={styles.linkCell}>
           <StatusIndicator status={value as string} />
-          <a href={href} className={styles.linkOverlay} />
+          <Link href={href} prefetch={false} className={styles.linkOverlay} />
         </TableCell>
       );
     } else if (header === 'submittedAt') {
@@ -162,7 +163,7 @@ export default function TestRunsTable({
       cellComponent = (
         <TableCell className={styles.linkCell}>
           {formatDate(new Date(value))}
-          <a href={href} className={styles.linkOverlay} />
+          <Link href={href} prefetch={false} className={styles.linkOverlay} />
         </TableCell>
       );
     }

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -44,6 +44,7 @@ import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
 interface CustomCellProps {
   header: string;
   value: any;
+  href: string;
 }
 
 interface TestRunsTableProps {
@@ -144,8 +145,13 @@ export default function TestRunsTable({
    * This component encapsulates the logic for rendering a cell.
    * It renders a special layout for the 'result' column and a default for all others.
    */
-  const CustomCell = ({ header, value }: CustomCellProps) => {
-    let cellComponent = <TableCell>{value}</TableCell>;
+  const CustomCell = ({ header, value, href }: CustomCellProps) => {
+    let cellComponent = (
+      <TableCell className={styles.linkCell}>
+        {value}
+        <a href={href} className={styles.linkOverlay} />
+      </TableCell>
+    );
 
     if (value === 'N/A' || !value) {
       return <TableCell>N/A</TableCell>;
@@ -153,13 +159,19 @@ export default function TestRunsTable({
 
     if (header === 'result') {
       cellComponent = (
-        <TableCell>
+        <TableCell className={styles.linkCell}>
           <StatusIndicator status={value as string} />
+          <a href={href} className={styles.linkOverlay} />
         </TableCell>
       );
     } else if (header === 'submittedAt') {
       // Format the date using the context's formatDate function
-      cellComponent = <TableCell>{formatDate(new Date(value))}</TableCell>;
+      cellComponent = (
+        <TableCell className={styles.linkCell}>
+          {formatDate(new Date(value))}
+          <a href={href} className={styles.linkOverlay} />
+        </TableCell>
+      );
     }
 
     return cellComponent;
@@ -227,7 +239,12 @@ export default function TestRunsTable({
                       className={styles.clickableRow}
                     >
                       {row.cells.map((cell) => (
-                        <CustomCell key={cell.id} value={cell.value} header={cell.info.header} />
+                        <CustomCell
+                          key={cell.id}
+                          value={cell.value}
+                          header={cell.info.header}
+                          href={`/test-runs/${row.id}`}
+                        />
                       ))}
                     </TableRow>
                   ))}

--- a/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/utils/constants/common';
 import { NotificationType } from '@/utils/types/common';
 import { TreeNodeData } from '@/utils/functions/artifacts';
+import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 
 interface TestRunDetailsProps {
   runId: string;
@@ -59,7 +60,7 @@ const TestRunDetails = ({
   runArtifactsPromise,
 }: TestRunDetailsProps) => {
   const translations = useTranslations('TestRunDetails');
-  const { breadCrumbItems } = useHistoryBreadCrumbs();
+  const { breadCrumbItems, pushBreadCrumb } = useHistoryBreadCrumbs();
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
@@ -178,6 +179,16 @@ const TestRunDetails = ({
 
     loadRunDetails();
   }, [run, runDetailsPromise, runArtifactsPromise, runLogPromise, extractRunDetails]);
+
+  useEffect(() => {
+    // If the 'Test Runs' breadcrumb is already in the items, skip.
+    if (breadCrumbItems.length > 1) return;
+    // Push the Test Runs URL to the breadcrumb history.
+    pushBreadCrumb({
+      ...TEST_RUNS,
+      route: `/test-runs?${searchParams.toString()}`,
+    });
+  });
 
   const handleShare = async () => {
     try {

--- a/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
@@ -399,3 +399,15 @@
 .clickableRow {
   cursor: pointer;
 }
+
+.linkCell {
+  position: relative;
+  padding: 0;
+}
+
+.linkOverlay {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+

--- a/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
@@ -257,27 +257,6 @@ describe('TestRunsTable Interactions', () => {
     });
     expect(screen.queryByText('Test Run 1')).not.toBeInTheDocument();
   });
-
-  test('pushes test runs breadcrumb with current search params when a run is clicked', async () => {
-    // Arrange
-    const mockRuns = generateMockRuns(1);
-    // Provide a specific set of search params for this test's context
-    const specificSearchParams = new URLSearchParams('status=finished&requestor=user1');
-    mockUseSearchParams.mockReturnValue(specificSearchParams);
-
-    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
-
-    // Act
-    const tableRow = await screen.findByText('Test Run 1');
-    fireEvent.click(tableRow);
-
-    // Assert
-    // Check that the breadcrumb route is built from the mocked search params
-    expect(pushBreadCrumbMock).toHaveBeenCalledWith({
-      title: 'testRuns',
-      route: `/test-runs?${specificSearchParams.toString()}`,
-    });
-  });
 });
 
 describe('TestRunsTable rendering of TableCells', () => {

--- a/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
@@ -279,3 +279,27 @@ describe('TestRunsTable Interactions', () => {
     });
   });
 });
+
+describe('TestRunsTable rendering of TableCells', () => {
+  test('places an anchor with the correct href in every table cell', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(8);
+
+    // Act
+    render(<TestRunsTable {...defaultProps} runsList={mockRuns} />);
+
+    // Assert
+    const tableRows = screen.getAllByRole('row').slice(1); // Get all rows other than the header
+
+    tableRows.forEach((row, rowIndex) => {
+      const rowRunId = mockRuns[rowIndex].id;
+      const cells = within(row).getAllByRole('cell'); // Get all cells in the row
+
+      cells.forEach((cell) => {
+        // Every cell should have a link as no null value cells are in the mock data
+        const link = within(cell).getByRole('link');
+        expect(link).toHaveAttribute('href', `/test-runs/${rowRunId}`);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2486

## Changes

- Allow users to right click a row in the Test Runs table and open the test run in a new tab:
   - Embed an anchor element into each cell in the Test Runs table. The anchor element has an href attribute of the URL for the test run page associated with that cell's row. This will allow users to right click on any cell in a row, and choose to copy the link or open that link in a new tab if they wish. 
   - Two new style classes added to the CSS file for the cells and the link overlay from the anchor element.
   - Unit test to validate that every table cell has a link with the correct href to its run.
- Push the 'Test Runs' breadcrumb to the trail on load of a 'Test Run: xxx' page, instead of on click of a row on the Test Runs table. This is so the breadcrumb is added to the trail both when the row is clicked, and if a user opens a new tab, to go to a Test Run page.
   - Unit tests updated.
