### PR TITLE
Bump development version to 0.46.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaFrameworkVersion = "0.45.0"
+def galasaFrameworkVersion = "0.46.0"
 def galasaOpenApiYamlVersion = galasaFrameworkVersion
 
 repositories {

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -6,7 +6,7 @@
 
 import { ColumnDefinition } from '../interfaces';
 
-const CLIENT_API_VERSION = '0.45.0';
+const CLIENT_API_VERSION = '0.46.0';
 
 const COLORS = {
   RED: '#da1e28',


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2470