### PR TITLE
Update Tests to Include Viewer Role 

### DIFF
--- a/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
+++ b/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
@@ -96,6 +96,9 @@ const dummyRoles: RBACRole[] = [
   {
     metadata: { id: '3', name: 'owner', description: 'Owner of Galasa service', assignable: false },
   },
+  {
+    metadata: { id: '4', name: 'viewer', description: 'User can view Galasa test results', assignable: true },
+  }
 ];
 
 describe('UserRoleSection', () => {
@@ -199,7 +202,7 @@ describe('UserRoleSection', () => {
     await waitFor(() => {
       const dropdown = screen.getByTestId('dropdown') as HTMLSelectElement;
       const options = dropdown.querySelectorAll('option');
-      expect(options.length).toBe(3);
+      expect(options.length).toBe(4);
     });
 
     const dropdown = screen.getByTestId('dropdown') as HTMLSelectElement;

--- a/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
+++ b/galasa-ui/src/tests/components/users/UserRoleSelection.test.tsx
@@ -97,8 +97,13 @@ const dummyRoles: RBACRole[] = [
     metadata: { id: '3', name: 'owner', description: 'Owner of Galasa service', assignable: false },
   },
   {
-    metadata: { id: '4', name: 'viewer', description: 'User can view Galasa test results', assignable: true },
-  }
+    metadata: {
+      id: '4',
+      name: 'viewer',
+      description: 'User can view Galasa test results',
+      assignable: true,
+    },
+  },
 ];
 
 describe('UserRoleSection', () => {


### PR DESCRIPTION
# Why?
Not a necessary PR as the roles are not fetched dynamically, but ensures consistency between tests and actual implementation with the new `viewer` role added in [#2504](https://github.com/galasa-dev/projectmanagement/issues/2504).