### PR TITLE
Remove 'page' query parameter from request to get runs as it no longer exists

### DIFF
--- a/galasa-ui/src/tests/functions/fetchAllTestRunsByPaging.test.tsx
+++ b/galasa-ui/src/tests/functions/fetchAllTestRunsByPaging.test.tsx
@@ -84,7 +84,6 @@ describe('fetchAllTestRunsByPaging Function', () => {
       new Date('2023-10-26T00:00:00.000Z'),
       new Date('2023-10-27T00:00:00.000Z'),
       undefined,
-      undefined,
       4,
       undefined,
       undefined,

--- a/galasa-ui/src/utils/testRuns.ts
+++ b/galasa-ui/src/utils/testRuns.ts
@@ -103,7 +103,6 @@ export const fetchAllTestRunsByPaging = async ({
         fromDate,
         toDate,
         testName,
-        undefined, // page
         BATCH_SIZE,
         undefined, // runId
         runName,


### PR DESCRIPTION
## Why?
Related to changes in https://github.com/galasa-dev/galasa/pull/497

## Changes
- [x] Removed the use of the `page` query parameter when getting runs from the API server since that query parameter no longer exists