### PR TITLE
Set the correct initial state for the timeframe to fix the specific from/to times not working properly, remove unused imports

### DIFF
--- a/galasa-ui/src/components/HomeContent.tsx
+++ b/galasa-ui/src/components/HomeContent.tsx
@@ -8,7 +8,6 @@ import { Section } from '@carbon/react';
 import styles from '@/styles/HomeContent.module.css';
 import { useEffect, useState } from 'react';
 import MarkdownIt from 'markdown-it';
-import { useRouter } from 'next/navigation';
 import AccessDeniedModal from './common/AccessDeniedModal';
 import { MarkdownResponse } from '@/utils/interfaces';
 
@@ -19,7 +18,6 @@ interface HomeContentProps {
 export default function HomeContent({ markdownContentPromise }: HomeContentProps) {
   const [renderedHtmlContent, setRenderedHtmlContent] = useState<string>('');
   const [isAccessAllowed, setIsAccessAllowed] = useState(true);
-  const router = useRouter();
 
   useEffect(() => {
     let md = new MarkdownIt({

--- a/galasa-ui/src/components/headers/PageHeaderMenu.tsx
+++ b/galasa-ui/src/components/headers/PageHeaderMenu.tsx
@@ -5,7 +5,7 @@
  */
 'use client';
 
-import React, { useEffect } from 'react';
+import React from 'react';
 import { HeaderGlobalBar, OverflowMenu, OverflowMenuItem, HeaderName } from '@carbon/react';
 import { User } from '@carbon/icons-react';
 import { useRouter } from 'next/navigation';

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -16,26 +16,18 @@ import {
   Pagination,
   DataTableSkeleton,
 } from '@carbon/react';
-import {
-  ColumnDefinition,
-  DataTableHeader,
-  DataTableRow,
-  DataTableCell as IDataTableCell,
-  runStructure,
-} from '@/utils/interfaces';
+import { ColumnDefinition, DataTableHeader, DataTableRow, runStructure } from '@/utils/interfaces';
 import styles from '@/styles/test-runs/TestRunsPage.module.css';
 import { TableRowProps } from '@carbon/react/lib/components/DataTable/TableRow';
 import { TableHeadProps } from '@carbon/react/lib/components/DataTable/TableHead';
 import { TableBodyProps } from '@carbon/react/lib/components/DataTable/TableBody';
 import StatusIndicator from '../../common/StatusIndicator';
 import { useMemo, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import ErrorPage from '@/app/error/page';
 import { MAX_DISPLAYABLE_TEST_RUNS, RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
 import { useTranslations } from 'next-intl';
 import { InlineNotification } from '@carbon/react';
-import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
-import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 import { useDateTimeFormat } from '@/contexts/DateTimeFormatContext';
 import { useDisappearingNotification } from '@/hooks/useDisappearingNotification';
 import { getTimeframeText } from '@/utils/functions/timeFrameText';
@@ -68,16 +60,11 @@ export default function TestRunsTable({
   orderedHeaders,
   isLoading,
   isError,
-  isRelativeToNow,
-  durationDays,
-  durationHours,
-  durationMinutes,
 }: TestRunsTableProps) {
   const translations = useTranslations('TestRunsTable');
   const { formatDate } = useDateTimeFormat();
 
   const router = useRouter();
-  const searchParams = useSearchParams();
 
   const [currentPage, setCurrentPage] = useState(1);
 

--- a/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/ArtifactsTab.tsx
@@ -23,8 +23,6 @@ import { Tile } from '@carbon/react';
 import { cleanArtifactPath, handleDownload } from '@/utils/artifacts';
 import { useTranslations } from 'next-intl';
 import { Button } from '@carbon/react';
-import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 import {
   FolderNode,
   ArtifactDetails,

--- a/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
@@ -121,11 +121,11 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
   const { getResolvedTimeZone } = useDateTimeFormat();
 
   const [notification, setNotification] = useState<Notification | null>(null);
-  const [selectedFromOption, setSelectedFromOption] = useState<FromSelectionOptions | null>(
-    FromSelectionOptions.specificFromTime
+  const [selectedFromOption, setSelectedFromOption] = useState<FromSelectionOptions>(
+    FromSelectionOptions.duration
   );
-  const [selectedToOption, setSelectedToOption] = useState<ToSelectionOptions | null>(
-    ToSelectionOptions.specificToTime
+  const [selectedToOption, setSelectedToOption] = useState<ToSelectionOptions>(
+    ToSelectionOptions.now
   );
   const [hasInitialized, setHasInitialized] = useState(false);
 

--- a/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
@@ -127,7 +127,6 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
   const [selectedToOption, setSelectedToOption] = useState<ToSelectionOptions>(
     ToSelectionOptions.now
   );
-  const [hasInitialized, setHasInitialized] = useState(false);
 
   const handleValueChange = useCallback(
     (field: keyof TimeFrameValues, value: any) => {
@@ -207,17 +206,8 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
 
       // Always sync the "To" option with isRelativeToNow
       setSelectedToOption(toOption);
-
-      // Only set the "From" option on initial load
-      if (!hasInitialized) {
-        const fromOption = values.isRelativeToNow
-          ? FromSelectionOptions.duration
-          : FromSelectionOptions.specificFromTime;
-        setSelectedFromOption(fromOption);
-        setHasInitialized(true);
-      }
     }
-  }, [values.isRelativeToNow, hasInitialized]);
+  }, [values.isRelativeToNow]);
 
   return (
     <div className={styles.timeFrameContainer}>

--- a/galasa-ui/src/tests/components/common/BreadCrumb.test.tsx
+++ b/galasa-ui/src/tests/components/common/BreadCrumb.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import BreadCrumb from '@/components/common/BreadCrumb';
 

--- a/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
+++ b/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import PageHeader from '@/components/headers/PageHeader';
 import React from 'react';
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagContext';

--- a/galasa-ui/src/tests/components/headers/PageHeaderMenu.test.tsx
+++ b/galasa-ui/src/tests/components/headers/PageHeaderMenu.test.tsx
@@ -8,7 +8,6 @@ import { useRouter } from 'next/navigation';
 import PageHeaderMenu from '@/components/headers/PageHeaderMenu';
 import React from 'react';
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagContext';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 
 const fetchMock = jest.spyOn(global, 'fetch');
 

--- a/galasa-ui/src/tests/components/test-runs/saved-queries/QueryItem.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/saved-queries/QueryItem.test.tsx
@@ -5,7 +5,7 @@
  */
 import React from 'react';
 import '@testing-library/jest-dom';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { NotificationType, SavedQueryType } from '@/utils/types/common';
 import QueryItem from '@/components/test-runs/saved-queries/QueryItem';
 import * as dndKitSortable from '@dnd-kit/sortable';

--- a/galasa-ui/src/tests/components/test-runs/test-run-details/3270Tab/TableOfScreenshots.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/test-run-details/3270Tab/TableOfScreenshots.test.tsx
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-import React, { useState } from 'react';
+import React from 'react';
 import { act, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import TableOfScreenshots from '@/components/test-runs/test-run-details/3270Tab/TableOfScreenshots';

--- a/galasa-ui/src/tests/components/test-runs/test-run-details/ArtifactsTab.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/test-run-details/ArtifactsTab.test.tsx
@@ -6,9 +6,7 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { TreeNodeData } from '@/utils/functions/artifacts';
 import { ArtifactsTab } from '@/components/test-runs/test-run-details/ArtifactsTab';
-import { checkForZosTerminalFolderStructure } from '@/utils/3270/checkFor3270FolderStructure';
 import { downloadArtifactFromServer } from '@/actions/runsAction';
 import { handleDownload } from '@/utils/artifacts';
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagContext';

--- a/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
@@ -8,8 +8,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import TimeFrameContent, {
   applyTimeFrameRules,
   calculateSynchronizedState,
+  FromSelectionOptions,
+  ToSelectionOptions,
 } from '@/components/test-runs/timeframe/TimeFrameContent';
-import { addMonths } from '@/utils/timeOperations';
 import { DAY_MS } from '@/utils/constants/common';
 import { TimeFrameValues } from '@/utils/interfaces';
 import { useState } from 'react';
@@ -391,6 +392,10 @@ describe('applyTimeFrameRules', () => {
       const toDateInput = screen.getByLabelText('To Date');
       const daysInput = screen.getByLabelText('Days');
 
+      // Click on the specific 'From' time radio button
+      const specificFromTimeRadio = screen.getByDisplayValue(FromSelectionOptions.specificFromTime);
+      fireEvent.click(specificFromTimeRadio);
+
       fireEvent.change(fromDateInput, { target: { value: '2025-08-12' } });
       fireEvent.change(toDateInput, { target: { value: '2025-08-15' } });
 
@@ -431,7 +436,13 @@ describe('applyTimeFrameRules', () => {
       const daysInput = screen.getByLabelText('Days');
       const minutesInput = screen.getByLabelText('Minutes');
 
+      const specificFromTimeRadio = screen.getByDisplayValue(FromSelectionOptions.specificFromTime);
+      const specificToTimeRadio = screen.getByDisplayValue(ToSelectionOptions.specificToTime);
+      fireEvent.click(specificFromTimeRadio);
+      fireEvent.click(specificToTimeRadio);
+
       // Change "From" date to be after "To" date
+      fireEvent.change(toDateInput, { target: { value: '08/12/2025' } });
       fireEvent.change(fromDateInput, { target: { value: '08/15/2025' } });
 
       // Check that the error notification is displayed
@@ -465,6 +476,9 @@ describe('applyTimeFrameRules', () => {
       const nowRadio = screen.getByLabelText('Now');
       // Check the initial value before the click
       expect(toDateInput).toHaveValue(new Date(initialTo).toLocaleDateString('en-US'));
+
+      const specificToTimeRadio = screen.getByDisplayValue(ToSelectionOptions.specificToTime);
+      fireEvent.click(specificToTimeRadio);
 
       // Act: Click the radio button
       fireEvent.click(nowRadio);

--- a/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
@@ -488,7 +488,7 @@ describe('applyTimeFrameRules', () => {
       });
     });
 
-    test('should sync "To" option when isRelativeToNow changes but keep "From" option unchanged after initialization', async () => {
+    test('should synchronize the "To" option when the query changes to be relative to now', async () => {
       const initialFrom = '2025-08-10T12:00:00.000Z';
       const initialTo = '2025-08-13T12:00:00.000Z';
 
@@ -497,18 +497,15 @@ describe('applyTimeFrameRules', () => {
           const initialFromDate = new Date(initialFrom);
           const initialToDate = new Date(initialTo);
 
-          return {
-            ...calculateSynchronizedState(initialFromDate, initialToDate, timezone),
-            isRelativeToNow: false, // Start with specific time (not relative to now)
-          };
+          return calculateSynchronizedState(initialFromDate, initialToDate, timezone);
         });
 
         return (
           <>
             <TimeFrameContent values={values} setValues={setValues} />
-            {/* Button to simulate external isRelativeToNow change}*/}
+            {/* Add a button to simulate a query change */}
             <button
-              data-testid="toggle-relative"
+              role="toggle-isRelativeToNow"
               onClick={() =>
                 setValues((prev) => ({ ...prev, isRelativeToNow: !prev.isRelativeToNow }))
               }
@@ -520,51 +517,42 @@ describe('applyTimeFrameRules', () => {
       };
 
       render(<TestWrapper />);
-
       const nowRadio = screen.getByLabelText('Now');
-      const specificToTimeRadio = screen.getByLabelText('A specific time', {
-        selector: '#to-specific-time',
-      });
-      const specificFromTimeRadio = screen.getByLabelText('A specific time', {
-        selector: '#from-specific-time',
-      });
+      const durationRadio = screen.getByDisplayValue(FromSelectionOptions.duration);
+      const specificToTimeRadio = screen.getByDisplayValue(ToSelectionOptions.specificToTime);
 
-      // Initial state: isRelativeToNow is false, so "A specific time" should be checked for both
+      // Check the initial state is set to 'duration' and 'now'
       await waitFor(() => {
-        expect(specificToTimeRadio).toBeChecked();
-        expect(specificFromTimeRadio).toBeChecked();
-      });
-
-      // Act: Manually select "Duration" for the "From" option
-      const durationFromRadio = screen.getByLabelText(/Duration before/i);
-      fireEvent.click(durationFromRadio);
-
-      await waitFor(() => {
-        expect(durationFromRadio).toBeChecked();
-      });
-
-      // Simulate an external change to isRelativeToNow to true
-      const toggleButton = screen.getByTestId('toggle-relative');
-      fireEvent.click(toggleButton);
-
-      // "To" option should sync to "Now" since isRelativeToNow is now true
-      await waitFor(() => {
+        expect(durationRadio).toBeChecked();
         expect(nowRadio).toBeChecked();
       });
 
-      // "From" option should remain as "Duration" (user's manual selection preserved)
-      expect(durationFromRadio).toBeChecked();
+      // Click the specific 'To' time radio button
+      fireEvent.click(specificToTimeRadio);
 
-      // Toggle isRelativeToNow back to false
-      fireEvent.click(toggleButton);
-
-      // "To" option should sync back to "A specific time"
       await waitFor(() => {
         expect(specificToTimeRadio).toBeChecked();
+        expect(nowRadio).not.toBeChecked();
       });
 
-      // "From" option should still remain as "Duration" (not reset to specific time)
-      expect(durationFromRadio).toBeChecked();
+      // Simulate a query change
+      const toggleButton = screen.getByRole('toggle-isRelativeToNow');
+      fireEvent.click(toggleButton);
+
+      // 'To' option should have switched from specific time to 'now'
+      await waitFor(() => {
+        expect(nowRadio).toBeChecked();
+        expect(specificToTimeRadio).not.toBeChecked();
+      });
+
+      // Simulate another query change
+      fireEvent.click(toggleButton);
+
+      // 'To' option should have switched back to specific time
+      await waitFor(() => {
+        expect(specificToTimeRadio).toBeChecked();
+        expect(nowRadio).not.toBeChecked();
+      });
     });
   });
 });

--- a/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameFilter.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameFilter.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import React from 'react';
-import { render, screen, within, fireEvent } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import TimeFrameFilter from '@/components/test-runs/timeframe/TimeFrameFilter';
 import { TimeFrameValues } from '@/utils/interfaces';
 import userEvent from '@testing-library/user-event';

--- a/galasa-ui/src/utils/constants/defaultQuery.ts
+++ b/galasa-ui/src/utils/constants/defaultQuery.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 import { encodeStateToUrlParam } from '../encoding/urlEncoder';
 import { DEFAULT_VISIBLE_COLUMNS, RESULTS_TABLE_COLUMNS, TEST_RUNS_QUERY_PARAMS } from './common';
 

--- a/galasa-ui/src/utils/encoding/urlStateMappers.ts
+++ b/galasa-ui/src/utils/encoding/urlStateMappers.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { TEST_RUNS_QUERY_PARAMS, TABS_IDS, TEST_RUNS_STATUS } from '../constants/common';
+import { TEST_RUNS_QUERY_PARAMS, TEST_RUNS_STATUS } from '../constants/common';
 
 // Mappings for keys and values to minify the URL state
 const keyMap: Record<string, string> = {

--- a/galasa-ui/src/utils/timeOperations.ts
+++ b/galasa-ui/src/utils/timeOperations.ts
@@ -220,26 +220,6 @@ export function getOneMonthAgo(): string {
 }
 
 /**
- * Accurately adds a number of months to a date, handling end-of-month edge cases.
- * If the original day doesn't exist in the target month, it will use the last valid day.
- *
- * @param date The starting date.
- * @param months The number of months to add.
- * @returns A new Date object.
- */
-export function addMonths(date: Date, months: number): Date {
-  const newDate = new Date(date);
-  const originalDay = newDate.getDate();
-  newDate.setMonth(newDate.getMonth() + months);
-
-  if (newDate.getDate() !== originalDay) {
-    newDate.setDate(0);
-  }
-
-  return newDate;
-}
-
-/**
  * Parses a time string and validates it.
  * If the string is a valid time (e.g., "9:5", "14:30"), it returns an object with the hour and minute.
  * Otherwise, it returns null.


### PR DESCRIPTION
## Why?
For https://github.com/galasa-dev/projectmanagement/issues/2514

Previously, the initial states for the selected "from" and "to" options were being set to the specific times even though the default query uses the "duration" and "now" options - this is because the `isRelativeToNow` value isn't set immediately, so the selected options always initialise to the wrong options.

This PR sets the default selected options to "duration" and "now", while also making sure that the "to" option remains synchronized with the `isRelativeToNow` value so that the correct "to" option is selected when switching between queries.

## Changes
- [x] Set the initial `selectedFromOption` and `selectedToOption` states in the timeframe tab to be `duration` and `now`, respectively
- [x] Removed unused imports from various components for a general tidy-up