### PR TITLE
Iss2485 - Add persistent toolbar to test runs table to allow users to filter table data

### DIFF
--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -98,32 +98,33 @@ export default function TestRunsTable({
   // Filter rows in the current paginatedRows if the text in the
   // persistent toolbar search box changes and matches any table info.
   const filteredRows = useMemo(() => {
+    if (!runsList || runsList.length === 0) {
+      return [];
+    }
+
     const searchLowerCase = search.toLowerCase();
+    const runStructureFields = Object.keys(runsList[0]) as (keyof runStructure)[];
     return runsList.filter((row) => {
-      const runFields = [
-        { column: 'submittedAt', value: row.submittedAt?.toLowerCase() ?? '' },
-        { column: 'runName', value: row.runName?.toLowerCase() ?? '' },
-        { column: 'requestor', value: row.requestor?.toLowerCase() ?? '' },
-        { column: 'user', value: row.user?.toLowerCase() ?? '' },
-        { column: 'group', value: row.group?.toLowerCase() ?? '' },
-        { column: 'bundle', value: row.bundle?.toLowerCase() ?? '' },
-        { column: 'package', value: row.package?.toLowerCase() ?? '' },
-        { column: 'testShortName', value: row.testShortName?.toLowerCase() ?? '' },
-        { column: 'testName', value: row.testName?.toLowerCase() ?? '' },
-        { column: 'tags', value: row.tags?.toLowerCase() ?? '' },
-        { column: 'status', value: row.status?.toLowerCase() ?? '' },
-        { column: 'result', value: row.result?.toLowerCase() ?? '' },
-        { column: 'submissionId', value: row.submissionId?.toLowerCase() ?? '' },
-      ];
-      // We only want to filter data in currently visible columns
-      const visibleRunFields = runFields.filter((field) => {
-        return currentVisibleColumns.split(',').includes(field.column);
-      });
-      return visibleRunFields.some((field) => {
-        return field.value.includes(searchLowerCase);
+      return runStructureFields.some((field) => {
+        // We only want to filter data in currently visible columns
+        if (!currentVisibleColumns.split(',').includes(field)) {
+          return false;
+        }
+        let value = '';
+        if (field === 'submittedAt') {
+          value =
+            row.submittedAt?.trim() !== ''
+              ? formatDate(new Date(row.submittedAt.toLowerCase()))
+              : '';
+        } else if (field === 'tags') {
+          value = row.tags?.trim() !== '' ? row.tags.toLowerCase() : 'n/a';
+        } else {
+          value = row[field]?.toLowerCase() ?? '';
+        }
+        return value.includes(searchLowerCase);
       });
     });
-  }, [currentVisibleColumns, runsList, search]);
+  }, [currentVisibleColumns, runsList, search, formatDate]);
 
   // Calculate the paginated rows based on the current page and page size,
   // and currently filtered rows (if there is a filter in the toolbar)

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -103,11 +103,12 @@ export default function TestRunsTable({
     }
 
     const searchLowerCase = search.toLowerCase();
+    const visibleColumnsSet = new Set(currentVisibleColumns.split(','));
     const runStructureFields = Object.keys(runsList[0]) as (keyof runStructure)[];
     return runsList.filter((row) => {
       return runStructureFields.some((field) => {
         // We only want to filter data in currently visible columns
-        if (!currentVisibleColumns.split(',').includes(field)) {
+        if (!visibleColumnsSet.has(field)) {
           return false;
         }
         let value = '';

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -105,23 +105,30 @@ export default function TestRunsTable({
   const filteredRows = useMemo(() => {
     const searchLowerCase = search.toLowerCase();
     return paginatedRows.filter((row) => {
-      const rowFields = [
-        row.submittedAt?.toLowerCase() ?? '',
-        row.runName?.toLowerCase() ?? '',
-        row.requestor?.toLowerCase() ?? '',
-        row.user?.toLowerCase() ?? '',
-        row.group?.toLowerCase() ?? '',
-        row.testName?.toLowerCase() ?? '',
-        row.tags?.toLowerCase() ?? '',
-        row.status?.toLowerCase() ?? '',
-        row.result?.toLowerCase() ?? '',
-        row.submissionId?.toLowerCase() ?? '',
+      const runFields = [
+        { column: 'submittedAt', value: row.submittedAt?.toLowerCase() ?? '' },
+        { column: 'runName', value: row.runName?.toLowerCase() ?? '' },
+        { column: 'requestor', value: row.requestor?.toLowerCase() ?? '' },
+        { column: 'user', value: row.user?.toLowerCase() ?? '' },
+        { column: 'group', value: row.group?.toLowerCase() ?? '' },
+        { column: 'bundle', value: row.bundle?.toLowerCase() ?? '' },
+        { column: 'package', value: row.package?.toLowerCase() ?? '' },
+        { column: 'testShortName', value: row.testShortName?.toLowerCase() ?? '' },
+        { column: 'testName', value: row.testName?.toLowerCase() ?? '' },
+        { column: 'tags', value: row.tags?.toLowerCase() ?? '' },
+        { column: 'status', value: row.status?.toLowerCase() ?? '' },
+        { column: 'result', value: row.result?.toLowerCase() ?? '' },
+        { column: 'submissionId', value: row.submissionId?.toLowerCase() ?? '' },
       ];
-      return rowFields.some((field) => {
-        return field.includes(searchLowerCase);
+      // We only want to filter data in currently visible columns
+      const visibleRunFields = runFields.filter((field) => {
+        return visibleColumns.includes(field.column);
+      });
+      return visibleRunFields.some((field) => {
+        return field.value.includes(searchLowerCase);
       });
     });
-  }, [paginatedRows, search]);
+  }, [visibleColumns, paginatedRows, search]);
 
   if (isError) {
     return <ErrorPage />;

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -112,12 +112,14 @@ export default function TestRunsTable({
           return false;
         }
         let value = '';
-        if (field === 'submittedAt') {
-          value =
-            row.submittedAt?.trim() !== ''
-              ? formatDate(new Date(row.submittedAt.toLowerCase()))
-              : '';
-        } else if (field === 'tags') {
+        // Reimplement in future - formatDate causes performance issues...
+        // if (field === 'submittedAt') {
+        //   value =
+        //     row.submittedAt?.trim() !== ''
+        //       ? formatDate(new Date(row.submittedAt.toLowerCase()))
+        //       : '';
+        // }
+        if (field === 'tags') {
           value = row.tags?.trim() !== '' ? row.tags.toLowerCase() : 'n/a';
         } else {
           value = row[field]?.toLowerCase() ?? '';
@@ -125,7 +127,7 @@ export default function TestRunsTable({
         return value.includes(searchLowerCase);
       });
     });
-  }, [currentVisibleColumns, runsList, search, formatDate]);
+  }, [currentVisibleColumns, runsList, search]);
 
   // Calculate the paginated rows based on the current page and page size,
   // and currently filtered rows (if there is a filter in the toolbar)


### PR DESCRIPTION
## Why?

Contributes to https://github.com/galasa-dev/projectmanagement/issues/2485

## Changes

- Adds a persistent toolbar to the test runs table to allow users to filter table data with a search text bar.
- The filter will update on each change of the search text, i.e., every new character typed/deleted.
- Users can filter by fields of a run that are currently visible, i.e., if the Bundle is `dev.galasa.zos` and the Test Name is `CICSTest`, but the Bundle is not visible in the table, the filter will match on `CICS` but not `zos`.
- Filter will search across the whole dataset in the table and collapse into the pages sizes, and also update the 'total' number in the pagination bar.
- Table is set back to page 1 when the filter is updated to avoid this situation: a filter with 6 pages of data, the user is on page 6, and then when a new filter is added with only 2 pages of data, the user has to scroll back through 4 empty pages.

Note:
- This is the first part of the story to make it quicker and easier to search by Run Name. Another PR will follow with a new dedicated search box that is visible at the top of the Test Runs page where users can search by Run Name only.