### PR TITLE
Iss2485 - Search test runs by run name with static Search box

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -311,6 +311,7 @@
     "title": "Testläufe",
     "errorTitle": "Fehler",
     "successTitle": "Erfolg",
+    "infoTitle": "Info",
     "copyMessage": "Seiten-URL kopieren",
     "copiedTitle": "URL erfolgreich kopiert: ",
     "copiedMessage": "Die URL dieser Seite wurde in die Zwischenablage kopiert.",
@@ -319,7 +320,10 @@
     "editQueryName": "Abfragenamen bearbeiten",
     "nameExistsError": "Eine Abfrage mit diesem Namen existiert bereits.",
     "queryUpdatedMessage": "Die Abfrage wurde erfolgreich aktualisiert.",
-    "newQuerySavedMessage": "Ihre Abfrage „{name}“ wurde erfolgreich gespeichert."
+    "newQuerySavedMessage": "Ihre Abfrage „{name}“ wurde erfolgreich gespeichert.",
+    "noTestRunsFoundMessage": "Keine Testläufe gefunden.",
+    "searchTextPlaceholder": "Suche nach Testlaufnamen",
+    "searchButtonLabel": "Gehen"
   },
   "TestRunSkeleton": {
     "status": "Status",

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -290,6 +290,7 @@
     "title": "Test Runs",
     "errorTitle": "Error",
     "successTitle": "Success",
+    "infoTitle": "Info",
     "copyMessage": "Copy page URL",
     "copiedTitle": "URL copy successful: ",
     "copiedMessage": "The URL for this page has been copied to the clipboard.",
@@ -298,7 +299,10 @@
     "editQueryName": "Edit Query Name",
     "nameExistsError": "A query with this name already exists.",
     "queryUpdatedMessage": "The query has been updated successfully.",
-    "newQuerySavedMessage": "Your query \"{name}\" was successfully saved."
+    "newQuerySavedMessage": "Your query \"{name}\" was successfully saved.",
+    "noTestRunsFoundMessage": "No test runs found.",
+    "searchTextPlaceholder": "Search by Test Run Name",
+    "searchButtonLabel": "Go"
   },
   "TestRunSkeleton": {
     "status": "Status",

--- a/galasa-ui/src/app/internal-api/test-runs/route.ts
+++ b/galasa-ui/src/app/internal-api/test-runs/route.ts
@@ -4,55 +4,71 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 import { DAY_MS, HOUR_MS, MINUTE_MS, TEST_RUNS_QUERY_PARAMS } from '@/utils/constants/common';
-import { fetchAllTestRunsByPaging } from '@/utils/testRuns';
+import { fetchAllTestRunsByPaging, fetchTestRunsByRunName } from '@/utils/testRuns';
 import { getYesterday } from '@/utils/timeOperations';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
 
-  // Get date range
-  let fromDate: Date = getYesterday();
-  let toDate: Date = new Date();
-  if (searchParams.has(TEST_RUNS_QUERY_PARAMS.DURATION)) {
-    // Handle duration-based filtering
-    const duration = searchParams.get(TEST_RUNS_QUERY_PARAMS.DURATION);
-    if (duration) {
-      const [days, hours, minutes] = duration.split(',').map(Number);
-      toDate = new Date();
-      fromDate = new Date(
-        toDate.getTime() - (days * DAY_MS + hours * HOUR_MS + minutes * MINUTE_MS)
-      );
-    }
-  } else if (
-    searchParams.has(TEST_RUNS_QUERY_PARAMS.FROM) &&
-    searchParams.has(TEST_RUNS_QUERY_PARAMS.TO)
-  ) {
-    // Handle fixed date range filtering
-    fromDate = new Date(searchParams.get('from')!);
-    toDate = new Date(searchParams.get('to')!);
-  }
-
-  const params = {
-    fromDate,
-    toDate,
-    runName: searchParams.get(TEST_RUNS_QUERY_PARAMS.RUN_NAME) || undefined,
-    requestor: searchParams.get(TEST_RUNS_QUERY_PARAMS.REQUESTOR) || undefined,
-    user: searchParams.get(TEST_RUNS_QUERY_PARAMS.USER) || undefined,
-    group: searchParams.get(TEST_RUNS_QUERY_PARAMS.GROUP) || undefined,
-    submissionId: searchParams.get(TEST_RUNS_QUERY_PARAMS.SUBMISSION_ID) || undefined,
-    bundle: searchParams.get(TEST_RUNS_QUERY_PARAMS.BUNDLE) || undefined,
-    testName: searchParams.get(TEST_RUNS_QUERY_PARAMS.TEST_NAME) || undefined,
-    result: searchParams.get(TEST_RUNS_QUERY_PARAMS.RESULT) || undefined,
-    status: searchParams.get(TEST_RUNS_QUERY_PARAMS.STATUS) || undefined,
-    tags: searchParams.get(TEST_RUNS_QUERY_PARAMS.TAGS) || undefined,
-  };
-
   try {
-    const data = await fetchAllTestRunsByPaging(params);
+    const data =
+      searchParams.size === 1 && searchParams.has(TEST_RUNS_QUERY_PARAMS.RUN_NAME)
+        ? await getRunByRunName(searchParams)
+        : await getRunsBySearchCriteria(searchParams);
+
     return NextResponse.json(data);
   } catch (error) {
     console.error('Error fetching test runs:', error);
     return NextResponse.json({ error: 'Failed to fetch test runs' }, { status: 500 });
+  }
+
+  async function getRunsBySearchCriteria(searchParams: URLSearchParams) {
+    // Get date range
+    let fromDate = getYesterday();
+    let toDate = new Date();
+    if (searchParams.has(TEST_RUNS_QUERY_PARAMS.DURATION)) {
+      // Handle duration-based filtering
+      const duration = searchParams.get(TEST_RUNS_QUERY_PARAMS.DURATION);
+      if (duration) {
+        const [days, hours, minutes] = duration.split(',').map(Number);
+        toDate = new Date();
+        fromDate = new Date(
+          toDate.getTime() - (days * DAY_MS + hours * HOUR_MS + minutes * MINUTE_MS)
+        );
+      }
+    } else if (
+      searchParams.has(TEST_RUNS_QUERY_PARAMS.FROM) &&
+      searchParams.has(TEST_RUNS_QUERY_PARAMS.TO)
+    ) {
+      // Handle fixed date range filtering
+      fromDate = new Date(searchParams.get('from')!);
+      toDate = new Date(searchParams.get('to')!);
+    }
+
+    const params = {
+      fromDate,
+      toDate,
+      runName: searchParams.get(TEST_RUNS_QUERY_PARAMS.RUN_NAME) || undefined,
+      requestor: searchParams.get(TEST_RUNS_QUERY_PARAMS.REQUESTOR) || undefined,
+      user: searchParams.get(TEST_RUNS_QUERY_PARAMS.USER) || undefined,
+      group: searchParams.get(TEST_RUNS_QUERY_PARAMS.GROUP) || undefined,
+      submissionId: searchParams.get(TEST_RUNS_QUERY_PARAMS.SUBMISSION_ID) || undefined,
+      bundle: searchParams.get(TEST_RUNS_QUERY_PARAMS.BUNDLE) || undefined,
+      testName: searchParams.get(TEST_RUNS_QUERY_PARAMS.TEST_NAME) || undefined,
+      result: searchParams.get(TEST_RUNS_QUERY_PARAMS.RESULT) || undefined,
+      status: searchParams.get(TEST_RUNS_QUERY_PARAMS.STATUS) || undefined,
+      tags: searchParams.get(TEST_RUNS_QUERY_PARAMS.TAGS) || undefined,
+    };
+
+    return fetchAllTestRunsByPaging(params);
+  }
+
+  async function getRunByRunName(searchParams: URLSearchParams) {
+    const params = {
+      runName: searchParams.get(TEST_RUNS_QUERY_PARAMS.RUN_NAME) || undefined,
+    };
+
+    return fetchTestRunsByRunName(params);
   }
 }

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -7,11 +7,11 @@
 import BreadCrumb from '@/components/common/BreadCrumb';
 import TestRunsTabs from '@/components/test-runs/TestRunsTabs';
 import styles from '@/styles/test-runs/TestRunsPage.module.css';
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { FormEvent, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
 import { useTranslations } from 'next-intl';
 import { NotificationType } from '@/utils/types/common';
-import { Button, InlineNotification } from '@carbon/react';
+import { Button, InlineNotification, Search } from '@carbon/react';
 import { Share } from '@carbon/icons-react';
 import PageTile from '../PageTile';
 import CollapsibleSideBar from './saved-queries/CollapsibleSideBar';
@@ -25,6 +25,8 @@ import {
 import { decodeStateFromUrlParam, encodeStateToUrlParam } from '@/utils/encoding/urlEncoder';
 import QueryName from './QueryName';
 import { generateUniqueQueryName } from '@/utils/functions/savedQueries';
+import { TestRunsData } from '@/utils/testRuns';
+import { useRouter } from 'next/navigation';
 
 interface TestRunsDetailsProps {
   requestorNamesPromise: Promise<string[]>;
@@ -45,9 +47,15 @@ export default function TestRunsDetails({
   const [isEditingName, setIsEditingName] = useState<boolean>(false);
   const [editedName, setEditedName] = useState<string>('');
 
+  const [currentSearchInput, setCurrentSearchInput] = useState('');
+  const [goButtonDisabled, setGoButtonDisabled] = useState(true);
+  const [searchNotification, setSearchNotification] = useState<NotificationType | null>(null);
+
   const inputRef = useRef<HTMLInputElement>(null);
 
   const activeQuery = getQueryByName(queryName);
+
+  const router = useRouter();
 
   // Focus and select the input when editing
   useEffect(() => {
@@ -219,9 +227,91 @@ export default function TestRunsDetails({
     return isDisabled;
   }, [activeQuery, searchParams, isQuerySaved, queryName]);
 
+  // Execute the search for test runs by run name using the Search input
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    const searchRunName = currentSearchInput.toUpperCase();
+    // Search from earliest time to now as timeframe is irrelevant
+    const searchFrom = new Date(Date.UTC(0, 0, 1, 0, 0, 0)).toISOString();
+    const searchTo = new Date().toISOString();
+
+    const url = new URL(
+      `/internal-api/test-runs?runName=${searchRunName}&from=${searchFrom}&to=${searchTo}`,
+      window.location.origin
+    );
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || `Server responded with status ${response.status}`);
+    }
+
+    const testRunsData = (await response.json()) as TestRunsData;
+    const runs = testRunsData.runs;
+    if (runs.length === 0) {
+      setSearchNotification({
+        kind: 'info',
+        title: translations('infoTitle'),
+        subtitle: translations('noTestRunsFoundMessage'),
+      });
+      setTimeout(() => setSearchNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+    } else if (runs.length === 1) {
+      // Navigate to the test run details page for this run
+      let runId = runs[0].runId;
+      router.push(`/test-runs/${runId}`);
+    } else {
+      // Re-runs were found
+      // Navigate to the test run details page for the latest try of this run
+      const latestRun = runs.reduce((latest, current) => {
+        const latestTime = new Date(latest.testStructure?.startTime ?? '').getTime();
+        const currentTime = new Date(current.testStructure?.startTime ?? '').getTime();
+        return currentTime > latestTime ? current : latest;
+      });
+      let runId = latestRun.runId;
+      router.push(`/test-runs/${runId}`);
+    }
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentSearchInput(event.target.value);
+    if (event.target.value === '') {
+      setGoButtonDisabled(true);
+    } else {
+      setGoButtonDisabled(false);
+    }
+  };
+
   return (
     <div className={styles.testRunsPage}>
-      <BreadCrumb breadCrumbItems={breadCrumbItems} />
+      <div className={styles.breadcrumbAndSearch}>
+        <BreadCrumb breadCrumbItems={breadCrumbItems} />
+        <form onSubmit={onSubmit}>
+          <div className={styles.searchAndButton}>
+            <Search
+              id="search-input"
+              className={styles.search}
+              placeholder={translations('searchTextPlaceholder')}
+              size="md"
+              type="text"
+              onChange={handleSearchChange}
+            />
+            <Button type="submit" size="md" disabled={goButtonDisabled}>
+              {translations('searchButtonLabel')}
+            </Button>
+            {searchNotification && (
+              <div className={styles.notification}>
+                <InlineNotification
+                  title={searchNotification.title}
+                  subtitle={searchNotification.subtitle}
+                  kind={searchNotification.kind}
+                  hideCloseButton={true}
+                />
+              </div>
+            )}
+          </div>
+        </form>
+      </div>
       <PageTile translationKey="TestRun.title" className={styles.toolbar}>
         <div className={styles.toolbarActions}>
           <Button

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -7,11 +7,11 @@
 import BreadCrumb from '@/components/common/BreadCrumb';
 import TestRunsTabs from '@/components/test-runs/TestRunsTabs';
 import styles from '@/styles/test-runs/TestRunsPage.module.css';
-import { FormEvent, Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
 import { useTranslations } from 'next-intl';
 import { NotificationType } from '@/utils/types/common';
-import { Button, InlineNotification, Search } from '@carbon/react';
+import { Button, InlineNotification } from '@carbon/react';
 import { Share } from '@carbon/icons-react';
 import PageTile from '../PageTile';
 import CollapsibleSideBar from './saved-queries/CollapsibleSideBar';
@@ -25,8 +25,7 @@ import {
 import { decodeStateFromUrlParam, encodeStateToUrlParam } from '@/utils/encoding/urlEncoder';
 import QueryName from './QueryName';
 import { generateUniqueQueryName } from '@/utils/functions/savedQueries';
-import { TestRunsData } from '@/utils/testRuns';
-import { useRouter } from 'next/navigation';
+import TestRunsSearch from './TestRunsSearch';
 
 interface TestRunsDetailsProps {
   requestorNamesPromise: Promise<string[]>;
@@ -47,15 +46,9 @@ export default function TestRunsDetails({
   const [isEditingName, setIsEditingName] = useState<boolean>(false);
   const [editedName, setEditedName] = useState<string>('');
 
-  const [currentSearchInput, setCurrentSearchInput] = useState('');
-  const [goButtonDisabled, setGoButtonDisabled] = useState(true);
-  const [searchNotification, setSearchNotification] = useState<NotificationType | null>(null);
-
   const inputRef = useRef<HTMLInputElement>(null);
 
   const activeQuery = getQueryByName(queryName);
-
-  const router = useRouter();
 
   // Focus and select the input when editing
   useEffect(() => {
@@ -227,91 +220,9 @@ export default function TestRunsDetails({
     return isDisabled;
   }, [activeQuery, searchParams, isQuerySaved, queryName]);
 
-  // Execute the search for test runs by run name using the Search input
-  const onSubmit = async (event: FormEvent) => {
-    event.preventDefault();
-
-    const searchRunName = currentSearchInput.toUpperCase();
-    // Search from earliest time to now as timeframe is irrelevant
-    const searchFrom = new Date(Date.UTC(0, 0, 1, 0, 0, 0)).toISOString();
-    const searchTo = new Date().toISOString();
-
-    const url = new URL(
-      `/internal-api/test-runs?runName=${searchRunName}&from=${searchFrom}&to=${searchTo}`,
-      window.location.origin
-    );
-    const response = await fetch(url.toString());
-
-    if (!response.ok) {
-      const errorData = await response.json().catch(() => null);
-      throw new Error(errorData?.error || `Server responded with status ${response.status}`);
-    }
-
-    const testRunsData = (await response.json()) as TestRunsData;
-    const runs = testRunsData.runs;
-    if (runs.length === 0) {
-      setSearchNotification({
-        kind: 'info',
-        title: translations('infoTitle'),
-        subtitle: translations('noTestRunsFoundMessage'),
-      });
-      setTimeout(() => setSearchNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
-    } else if (runs.length === 1) {
-      // Navigate to the test run details page for this run
-      let runId = runs[0].runId;
-      router.push(`/test-runs/${runId}`);
-    } else {
-      // Re-runs were found
-      // Navigate to the test run details page for the latest try of this run
-      const latestRun = runs.reduce((latest, current) => {
-        const latestTime = new Date(latest.testStructure?.startTime ?? '').getTime();
-        const currentTime = new Date(current.testStructure?.startTime ?? '').getTime();
-        return currentTime > latestTime ? current : latest;
-      });
-      let runId = latestRun.runId;
-      router.push(`/test-runs/${runId}`);
-    }
-  };
-
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setCurrentSearchInput(event.target.value);
-    if (event.target.value === '') {
-      setGoButtonDisabled(true);
-    } else {
-      setGoButtonDisabled(false);
-    }
-  };
-
   return (
     <div className={styles.testRunsPage}>
-      <div className={styles.breadcrumbAndSearch}>
-        <BreadCrumb breadCrumbItems={breadCrumbItems} />
-        <form onSubmit={onSubmit}>
-          <div className={styles.searchAndButton}>
-            <Search
-              id="search-input"
-              className={styles.search}
-              placeholder={translations('searchTextPlaceholder')}
-              size="md"
-              type="text"
-              onChange={handleSearchChange}
-            />
-            <Button type="submit" size="md" disabled={goButtonDisabled}>
-              {translations('searchButtonLabel')}
-            </Button>
-            {searchNotification && (
-              <div className={styles.notification}>
-                <InlineNotification
-                  title={searchNotification.title}
-                  subtitle={searchNotification.subtitle}
-                  kind={searchNotification.kind}
-                  hideCloseButton={true}
-                />
-              </div>
-            )}
-          </div>
-        </form>
-      </div>
+      <BreadCrumb breadCrumbItems={breadCrumbItems} />
       <PageTile translationKey="TestRun.title" className={styles.toolbar}>
         <div className={styles.toolbarActions}>
           <Button
@@ -337,6 +248,7 @@ export default function TestRunsDetails({
         <CollapsibleSideBar handleEditQueryName={handleStartEditingName} />
 
         <div className={styles.mainContent}>
+          <TestRunsSearch />
           <div className={styles.queryNameContainer}>
             <QueryName
               inputRef={inputRef}

--- a/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
@@ -27,14 +27,7 @@ export default function TestRunsSearch() {
     event.preventDefault();
 
     const searchRunName = currentSearchInput.toUpperCase();
-    // Search from earliest time to now as timeframe is irrelevant
-    const searchFrom = new Date(Date.UTC(0, 0, 1, 0, 0, 0)).toISOString();
-    const searchTo = new Date().toISOString();
-
-    const url = new URL(
-      `/internal-api/test-runs?runName=${searchRunName}&from=${searchFrom}&to=${searchTo}`,
-      window.location.origin
-    );
+    const url = new URL(`/internal-api/test-runs?runName=${searchRunName}`, window.location.origin);
     const response = await fetch(url.toString());
 
     if (!response.ok) {

--- a/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
@@ -1,0 +1,109 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import styles from '@/styles/test-runs/TestRunsSearch.module.css';
+import { NotificationType } from '@/utils/types/common';
+import { Search } from '@carbon/react';
+import { useTranslations } from 'next-intl';
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { TestRunsData } from '@/utils/testRuns';
+import { NOTIFICATION_VISIBLE_MILLISECS } from '@/utils/constants/common';
+import { Button } from '@carbon/react';
+import { InlineNotification } from '@carbon/react';
+
+export default function TestRunsSearch() {
+  const router = useRouter();
+  const translations = useTranslations('TestRunsDetails');
+
+  const [currentSearchInput, setCurrentSearchInput] = useState('');
+  const [goButtonDisabled, setGoButtonDisabled] = useState(true);
+  const [searchNotification, setSearchNotification] = useState<NotificationType | null>(null);
+
+  // Execute the search for test runs by run name using the Search input
+  const onSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+
+    const searchRunName = currentSearchInput.toUpperCase();
+    // Search from earliest time to now as timeframe is irrelevant
+    const searchFrom = new Date(Date.UTC(0, 0, 1, 0, 0, 0)).toISOString();
+    const searchTo = new Date().toISOString();
+
+    const url = new URL(
+      `/internal-api/test-runs?runName=${searchRunName}&from=${searchFrom}&to=${searchTo}`,
+      window.location.origin
+    );
+    const response = await fetch(url.toString());
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => null);
+      throw new Error(errorData?.error || `Server responded with status ${response.status}`);
+    }
+
+    const testRunsData = (await response.json()) as TestRunsData;
+    const runs = testRunsData.runs;
+    if (runs.length === 0) {
+      setSearchNotification({
+        kind: 'info',
+        title: translations('infoTitle'),
+        subtitle: translations('noTestRunsFoundMessage'),
+      });
+      setTimeout(() => setSearchNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+    } else if (runs.length === 1) {
+      // Navigate to the test run details page for this run
+      let runId = runs[0].runId;
+      router.push(`/test-runs/${runId}`);
+    } else {
+      // Re-runs were found
+      // Navigate to the test run details page for the latest try of this run
+      const latestRun = runs.reduce((latest, current) => {
+        const latestTime = new Date(latest.testStructure?.startTime ?? '').getTime();
+        const currentTime = new Date(current.testStructure?.startTime ?? '').getTime();
+        return currentTime > latestTime ? current : latest;
+      });
+      let runId = latestRun.runId;
+      router.push(`/test-runs/${runId}`);
+    }
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setCurrentSearchInput(event.target.value);
+    if (event.target.value === '') {
+      setGoButtonDisabled(true);
+    } else {
+      setGoButtonDisabled(false);
+    }
+  };
+
+  return (
+    <div className={styles.searchContainer}>
+      <form onSubmit={onSubmit}>
+        <div className={styles.searchAndButton}>
+          <Search
+            id="search-input"
+            className={styles.search}
+            placeholder={translations('searchTextPlaceholder')}
+            size="md"
+            type="text"
+            onChange={handleSearchChange}
+          />
+          <Button type="submit" size="md" disabled={goButtonDisabled}>
+            {translations('searchButtonLabel')}
+          </Button>
+          {searchNotification && (
+            <div className={styles.notification}>
+              <InlineNotification
+                title={searchNotification.title}
+                subtitle={searchNotification.subtitle}
+                kind={searchNotification.kind}
+                hideCloseButton={true}
+              />
+            </div>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
@@ -44,6 +44,7 @@ import {
 import { NotificationType } from '@/utils/types/common';
 import { TreeNodeData } from '@/utils/functions/artifacts';
 import { TEST_RUNS } from '@/utils/constants/breadcrumb';
+import TestRunsSearch from '../TestRunsSearch';
 
 interface TestRunDetailsProps {
   runId: string;
@@ -346,6 +347,7 @@ const TestRunDetails = ({
         <TestRunSkeleton selectedTabIndex={selectedTabIndex} />
       ) : (
         <div className={styles.testRunContainer}>
+          <TestRunsSearch />
           <div className={styles.summarySection}>
             <div>
               <span className={styles.summaryStatus}>

--- a/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
@@ -19,7 +19,7 @@
 .mainContent {
   flex: 1;
   min-width: 0;
-  padding: 5rem 4rem;
+  padding: 2.5rem 4rem;
 }
 
 @media (max-width: 768px) {
@@ -411,19 +411,3 @@
   z-index: 1;
 }
 
-.breadcrumbAndSearch {
-  display: flex;
-  justify-content: space-between;
-  background-color: var(--cds-layer);
-  align-items: center;
-  padding-right: 3rem;
-}
-
-.searchAndButton {
-  display: flex;
-  align-items: center;
-}
-
-.search {
-  width: 250px;
-}

--- a/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
@@ -410,3 +410,20 @@
   inset: 0;
   z-index: 1;
 }
+
+.breadcrumbAndSearch {
+  display: flex;
+  justify-content: space-between;
+  background-color: var(--cds-layer);
+  align-items: center;
+  padding-right: 3rem;
+}
+
+.searchAndButton {
+  display: flex;
+  align-items: center;
+}
+
+.search {
+  width: 250px;
+}

--- a/galasa-ui/src/styles/test-runs/TestRunsSearch.module.css
+++ b/galasa-ui/src/styles/test-runs/TestRunsSearch.module.css
@@ -1,0 +1,25 @@
+.searchContainer {
+  display: flex;
+  width: 100%;
+  margin-bottom: 2.5rem;
+}
+
+.searchContainer > * {
+  margin-left: auto;
+}
+
+.searchAndButton {
+  display: flex;
+  align-items: center;
+}
+
+.search {
+  width: 250px;
+}
+
+.notification {
+  position: fixed;
+  bottom: 5.5rem;
+  right: 1rem;
+  z-index: 9999;
+}

--- a/galasa-ui/src/styles/test-runs/test-run-details/TestRun.module.css
+++ b/galasa-ui/src/styles/test-runs/test-run-details/TestRun.module.css
@@ -5,7 +5,7 @@
  */
 .testRunContainer {
   width: 90%;
-  margin: 5rem auto 2rem auto;
+  margin: 2.5rem auto 2rem auto;
 }
 
 .tabs {

--- a/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
@@ -144,6 +144,7 @@ jest.mock('@carbon/react', () => ({
       Loading...
     </div>
   ),
+  Search: ({ ...props }: any) => <input {...props} data-testid="search" />,
 }));
 
 const renderWithProviders = (ui: React.ReactElement) => {
@@ -308,7 +309,7 @@ describe('TestRunsDetails', () => {
       await user.click(editButton);
 
       // 2. Type the new name
-      const input = screen.getByRole('textbox');
+      const input = screen.getByDisplayValue('Initial Query');
       expect(input).toHaveValue('Initial Query');
       await user.clear(input);
       await user.type(input, 'My Renamed Query');
@@ -348,7 +349,7 @@ describe('TestRunsDetails', () => {
 
       // Act
       await user.click(screen.getByRole('button', { name: /Edit query name/i }));
-      const input = screen.getByRole('textbox');
+      const input = screen.getByDisplayValue('Initial Query');
       await user.clear(input);
       await user.type(input, 'A Brand New Name');
       await user.tab();
@@ -373,7 +374,7 @@ describe('TestRunsDetails', () => {
 
       // Act
       await user.click(screen.getByRole('button', { name: /Edit query name/i }));
-      const input = screen.getByRole('textbox');
+      const input = screen.getByDisplayValue('Initial Query');
       await user.clear(input);
       await user.tab();
 
@@ -397,7 +398,7 @@ describe('TestRunsDetails', () => {
 
       await user.click(screen.getByRole('button', { name: /edit query name/i }));
 
-      const input = screen.getByRole('textbox');
+      const input = screen.getByDisplayValue('Initial Query');
       await user.clear(input);
       await user.type(input, 'Existing Name');
       await user.tab();

--- a/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
@@ -36,43 +36,6 @@ const mockRouter = {
 
 const mockGetResolvedTimeZone = jest.fn(() => 'UTC');
 
-const noRunsResponse = {
-  runs: [],
-};
-const singleRunResponse = {
-  runs: [
-    {
-      runId: 'run-123',
-      runName: 'U123',
-      testStructure: {
-        startTime: '2026-01-01T10:00:00Z',
-      },
-    },
-  ],
-};
-const multipleRunsResponse = {
-  runs: [
-    {
-      runId: 'run-1',
-      runName: 'U123', // same run name as below intentional.
-      testStructure: { startTime: '2026-01-01T10:00:00Z' },
-    },
-    {
-      runId: 'run-2',
-      runName: 'U123',
-      testStructure: { startTime: '2026-01-02T10:00:00Z' },
-    },
-  ],
-};
-
-// Mock the fetch that is called when "Search by Test Run Name" is used
-const mockFetchResponse = (data: any, ok = true) => {
-  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
-    ok,
-    json: async () => data,
-  } as Response);
-};
-
 // Mock useHistoryBreadCrumbs hook
 jest.mock('@/hooks/useHistoryBreadCrumbs', () => ({
   __esModule: true,
@@ -149,13 +112,11 @@ jest.mock('next-intl', () => ({
       copiedMessage: 'URL copied to clipboard.',
       errorTitle: 'Error',
       successTitle: 'Success',
-      infoTitle: 'Info',
       copyFailedMessage: 'Failed to copy URL.',
       editQueryName: 'Edit query name',
       nameExistsError: `Query with name "${vars?.name}" already exists.`,
       newQuerySavedMessage: `Query "${vars?.name}" has been saved.`,
       queryUpdatedMessage: 'The query has been updated successfully.',
-      noTestRunsFoundMessage: 'No test runs found.',
       saveQuery: 'Save Query',
     })[key] || key,
 }));
@@ -537,119 +498,6 @@ describe('TestRunsDetails', () => {
       // Verify button is  disabled
       const saveButton = screen.getByRole('button', { name: /Save Query/i });
       expect(saveButton).toBeDisabled();
-    });
-  });
-
-  describe('Search by Test Run Name', () => {
-    test('search go button disabled if search text is empty', async () => {
-      renderWithProviders(
-        <TestRunsDetails
-          requestorNamesPromise={mockRequestorNamesPromise}
-          resultsNamesPromise={mockResultsNamesPromise}
-        />
-      );
-
-      const searchInput = screen.getByTestId('search');
-      expect(searchInput).toHaveValue('');
-
-      const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
-      expect(goButton).toBeDisabled();
-    });
-
-    test('search go button enabled when search text is not empty', async () => {
-      const user = userEvent.setup();
-
-      renderWithProviders(
-        <TestRunsDetails
-          requestorNamesPromise={mockRequestorNamesPromise}
-          resultsNamesPromise={mockResultsNamesPromise}
-        />
-      );
-
-      const searchInput = screen.getByTestId('search');
-      expect(searchInput).toHaveValue('');
-
-      const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
-      expect(goButton).toBeDisabled();
-
-      await user.type(searchInput, 'U123');
-
-      expect(searchInput).toHaveValue('U123');
-      expect(goButton).toBeEnabled();
-    });
-    test('search by test run name one result takes you to test run details page', async () => {
-      const user = userEvent.setup();
-
-      mockFetchResponse(singleRunResponse);
-
-      renderWithProviders(
-        <TestRunsDetails
-          requestorNamesPromise={mockRequestorNamesPromise}
-          resultsNamesPromise={mockResultsNamesPromise}
-        />
-      );
-
-      const searchInput = screen.getByTestId('search');
-      const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
-
-      await user.type(searchInput, 'U123');
-      await user.click(goButton);
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
-      });
-
-      expect(mockRouter.push).toHaveBeenCalledWith('/test-runs/run-123');
-    });
-    test('search by test run name no results notifies no runs found', async () => {
-      const user = userEvent.setup();
-
-      mockFetchResponse(noRunsResponse);
-
-      renderWithProviders(
-        <TestRunsDetails
-          requestorNamesPromise={mockRequestorNamesPromise}
-          resultsNamesPromise={mockResultsNamesPromise}
-        />
-      );
-
-      const searchInput = screen.getByTestId('search');
-      const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
-
-      await user.type(searchInput, 'U123');
-      await user.click(goButton);
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
-      });
-
-      const notification = await screen.findByTestId('notification');
-      expect(notification).toHaveClass('notification-info');
-      expect(notification).toHaveTextContent('No test runs found.');
-    });
-    test('search by test run name multiple results takes you to latest runs test run details page', async () => {
-      const user = userEvent.setup();
-
-      mockFetchResponse(multipleRunsResponse);
-
-      renderWithProviders(
-        <TestRunsDetails
-          requestorNamesPromise={mockRequestorNamesPromise}
-          resultsNamesPromise={mockResultsNamesPromise}
-        />
-      );
-
-      const searchInput = screen.getByTestId('search');
-      const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
-
-      await user.type(searchInput, 'U123');
-      await user.click(goButton);
-
-      await waitFor(() => {
-        expect(global.fetch).toHaveBeenCalled();
-      });
-
-      expect(mockRouter.push).toHaveBeenCalledWith('/test-runs/run-2');
     });
   });
 });

--- a/galasa-ui/src/tests/components/test-runs/TestRunsSearch.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsSearch.test.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright contributors to the Galasa project
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+import TestRunsSearch from '@/components/test-runs/TestRunsSearch';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as Nav from 'next/navigation';
+
+let mockSearchParams = new URLSearchParams();
+
+const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn((newUrl) => {
+    const newQueryString = newUrl.split('?')[1] || '';
+    mockSearchParams = new URLSearchParams(newQueryString);
+  }),
+};
+
+const noRunsResponse = {
+  runs: [],
+};
+const singleRunResponse = {
+  runs: [
+    {
+      runId: 'run-123',
+      runName: 'U123',
+      testStructure: {
+        startTime: '2026-01-01T10:00:00Z',
+      },
+    },
+  ],
+};
+const multipleRunsResponse = {
+  runs: [
+    {
+      runId: 'run-1',
+      runName: 'U123', // same run name as below intentional.
+      testStructure: { startTime: '2026-01-01T10:00:00Z' },
+    },
+    {
+      runId: 'run-2',
+      runName: 'U123',
+      testStructure: { startTime: '2026-01-02T10:00:00Z' },
+    },
+  ],
+};
+
+// Mock the fetch that is called when "Search by Test Run Name" is used
+const mockFetchResponse = (data: any, ok = true) => {
+  return jest.spyOn(global, 'fetch').mockResolvedValueOnce({
+    ok,
+    json: async () => data,
+  } as Response);
+};
+
+// Mock next/navigation
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(() => '/mock-path'),
+  useSearchParams: jest.fn(() => mockSearchParams),
+  useRouter: jest.fn(() => mockRouter),
+}));
+
+// Carbon React mocks
+jest.mock('@carbon/react', () => ({
+  Button: ({ children, iconDescription, disabled, ...props }: any) => (
+    <button {...props} aria-label={iconDescription} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  InlineNotification: ({ title, subtitle, kind }: any) => (
+    <div data-testid="notification" className={`notification-${kind}`}>
+      <strong>{title}</strong>
+      <p>{subtitle}</p>
+    </div>
+  ),
+  Search: ({ ...props }: any) => <input {...props} data-testid="search" />,
+}));
+
+// Mock translations
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string, vars?: { name: string }) =>
+    ({
+      infoTitle: 'Info',
+      noTestRunsFoundMessage: 'No test runs found.',
+    })[key] || key,
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSearchParams = new URLSearchParams();
+  (Nav.useSearchParams as jest.Mock).mockImplementation(() => mockSearchParams);
+});
+
+describe('Search by Test Run Name', () => {
+  test('search go button disabled if search text is empty', async () => {
+    // Arrange
+    render(<TestRunsSearch></TestRunsSearch>);
+
+    // Act
+    const searchInput = screen.getByTestId('search');
+    expect(searchInput).toHaveValue('');
+
+    // Assert
+    const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
+    expect(goButton).toBeDisabled();
+  });
+
+  test('search go button enabled when search text is not empty', async () => {
+    // Arrange
+    render(<TestRunsSearch></TestRunsSearch>);
+    const user = userEvent.setup();
+
+    const searchInput = screen.getByTestId('search');
+    expect(searchInput).toHaveValue('');
+
+    const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
+    expect(goButton).toBeDisabled();
+
+    // Act
+    await user.type(searchInput, 'U123');
+
+    // Assert
+    expect(searchInput).toHaveValue('U123');
+    expect(goButton).toBeEnabled();
+  });
+
+  test('search by test run name one result takes you to test run details page', async () => {
+    // Arrange
+    render(<TestRunsSearch></TestRunsSearch>);
+    const user = userEvent.setup();
+
+    mockFetchResponse(singleRunResponse);
+
+    const searchInput = screen.getByTestId('search');
+    const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
+
+    // Act
+    await user.type(searchInput, 'U123');
+    await user.click(goButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Assert
+    expect(mockRouter.push).toHaveBeenCalledWith('/test-runs/run-123');
+  });
+
+  test('search by test run name no results notifies no runs found', async () => {
+    // Arrange
+    render(<TestRunsSearch></TestRunsSearch>);
+    const user = userEvent.setup();
+
+    mockFetchResponse(noRunsResponse);
+
+    const searchInput = screen.getByTestId('search');
+    const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
+
+    // Act
+    await user.type(searchInput, 'U123');
+    await user.click(goButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Assert
+    const notification = await screen.findByTestId('notification');
+    expect(notification).toHaveClass('notification-info');
+    expect(notification).toHaveTextContent('No test runs found.');
+  });
+
+  test('search by test run name multiple results takes you to latest runs test run details page', async () => {
+    // Arrange
+    render(<TestRunsSearch></TestRunsSearch>);
+    const user = userEvent.setup();
+
+    mockFetchResponse(multipleRunsResponse);
+
+    const searchInput = screen.getByTestId('search');
+    const goButton = screen.getByRole('button', { name: 'searchButtonLabel' });
+
+    // Act
+    await user.type(searchInput, 'U123');
+    await user.click(goButton);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    // Assert
+    expect(mockRouter.push).toHaveBeenCalledWith('/test-runs/run-2');
+  });
+});

--- a/galasa-ui/src/tests/components/test-runs/test-run-details/TestRunDetails.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/test-run-details/TestRunDetails.test.tsx
@@ -217,7 +217,21 @@ jest.mock('@carbon/react', () => {
     c.displayName = c.name || 'Anonymous';
   });
   Tile.displayName = 'Tile';
-  return { Tab, Tabs, TabList, TabPanels, TabPanel, Loading, Tile, InlineNotification, Button };
+  const Search = ({ ...props }: any) => {
+    return <input {...props} data-testid="search" />;
+  };
+  return {
+    Tab,
+    Tabs,
+    TabList,
+    TabPanels,
+    TabPanel,
+    Loading,
+    Tile,
+    InlineNotification,
+    Button,
+    Search,
+  };
 });
 
 beforeAll(() => {

--- a/galasa-ui/src/utils/testRuns.ts
+++ b/galasa-ui/src/utils/testRuns.ts
@@ -26,6 +26,10 @@ export interface TestRunsData {
   limitExceeded: boolean;
 }
 
+interface fetchTestRunsByRunNameParams {
+  runName?: string;
+}
+
 interface fetchAllTestRunsByPagingParams {
   fromDate: Date;
   toDate: Date;
@@ -47,6 +51,51 @@ interface fetchAllTestRunsByPagingParams {
 const getRasApiClient = () => {
   const apiConfig = createAuthenticatedApiConfiguration();
   return new ResultArchiveStoreAPIApi(apiConfig);
+};
+
+/**
+ * Fetches test runs from the Result Archive Store API with a specific run name.
+ *
+ * @param {string} [runName] - The name of the test run to filter by.
+ * @returns {Promise<TestRunsData>} - A promise that resolves to an object containing the runs and a flag indicating if the limit was reached.
+ */
+export const fetchTestRunsByRunName = async ({
+  runName,
+}: fetchTestRunsByRunNameParams): Promise<TestRunsData> => {
+  if (!runName) return { runs: [], limitExceeded: false };
+
+  let runs = [] as Run[];
+
+  const rasApiClient = getRasApiClient();
+  try {
+    const response: RunResults = await rasApiClient.getRasSearchRuns(
+      'from:desc',
+      CLIENT_API_VERSION,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      BATCH_SIZE,
+      undefined, // runId
+      runName,
+      undefined,
+      undefined,
+      undefined, // detail
+      undefined,
+      'true', // includeCursor
+      undefined
+    );
+
+    runs = response.runs || [];
+  } catch (error: any) {
+    console.error('Error fetching test runs:', error);
+  }
+
+  return { runs: runs, limitExceeded: false };
 };
 
 /**


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/2485

## Changes

- [x] New TestRunsSearch component that is available in the TestRunsDetails (table page) and TestRunDetails (details page) that allows users to search for tests by run name.
- [x] If a single run is found, they are routed directly to that test run details page.
- [x] If no run is found, an Info notification tells them.
- [x] If multiple re-runs are found of the same run name, the page will navigate to the latest instance of that run (i.e., the run that managed to finish, regardless of result).
- [x] The Go button attached to the Search component is disabled if the search input is blank.
- [x] New function in the internal-api which calls the RAS API with just a run name lookup instead of calling the pre-existing fetch runs with pagination that is too complex for this feature.
- [x] New jest tests to test the behaviour and rendering of TestRunsSearch.
- [x] Updates to existing jest tests for TestRunsDetails and TestRunDetails to support rendering of a `Search` component (fixes undefined elements).