### PR TITLE
Change development version to v0.46.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // Right now, the REST interface spec is always the same version as the galasa framework bundles.
-def galasaFrameworkVersion = "0.47.0"
+def galasaFrameworkVersion = "0.46.1"
 def galasaOpenApiYamlVersion = galasaFrameworkVersion
 
 repositories {

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -6,7 +6,7 @@
 
 import { ColumnDefinition } from '../interfaces';
 
-const CLIENT_API_VERSION = '0.47.0';
+const CLIENT_API_VERSION = '0.46.1';
 
 const COLORS = {
   RED: '#da1e28',


### PR DESCRIPTION
## Why?

We will be doing a patch release to remove a High CVE in assertj-core so I am downgrading the version to be released to v0.46.1 from v0.47.0 as another minor version should be saved for a feature release.