### PR TITLE
Iss2434 - Remove 'Test Runs' from experimental features

### DIFF
--- a/galasa-ui/messages/de.json
+++ b/galasa-ui/messages/de.json
@@ -30,7 +30,6 @@
     "title": "Experimentelle Funktionen",
     "description": "Früher Zugriff auf neue Funktionen. Diese Funktionen sind experimentell und können sich ändern oder entfernt werden.",
     "features": {
-      "testRunSearch": "Testlauf-Suche und Anzeige",
       "graph": "Testlauf-Diagramm"
     }
   },

--- a/galasa-ui/messages/en.json
+++ b/galasa-ui/messages/en.json
@@ -30,7 +30,6 @@
     "title": "Experimental Features",
     "description": "Early access to new features. These are experimental and subject to change or removal.",
     "features": {
-      "testRunSearch": "Test Run searching and viewing",
       "graph": "Test Run Graphs"
     }
   },

--- a/galasa-ui/src/components/headers/GalasaMenuItems.tsx
+++ b/galasa-ui/src/components/headers/GalasaMenuItems.tsx
@@ -6,20 +6,15 @@
 'use client';
 
 import { HeaderMenuItem } from '@carbon/react';
-import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 import { useTranslations } from 'next-intl';
 
 export default function GalasaMenuItems() {
-  const { isFeatureEnabled } = useFeatureFlags();
   const translations = useTranslations('PageHeader');
 
   return (
     <>
       <HeaderMenuItem href="/users">{translations('users')}</HeaderMenuItem>
-      {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS) && (
-        <HeaderMenuItem href="/test-runs">{translations('testRuns')}</HeaderMenuItem>
-      )}
+      <HeaderMenuItem href="/test-runs">{translations('testRuns')}</HeaderMenuItem>
     </>
   );
 }

--- a/galasa-ui/src/components/headers/PageHeader.tsx
+++ b/galasa-ui/src/components/headers/PageHeader.tsx
@@ -17,12 +17,9 @@ import PageHeaderMenu from './PageHeaderMenu';
 import Image from 'next/image';
 import galasaLogo from '@/assets/images/galasaLogo.png';
 import Link from 'next/link';
-import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 import { useTranslations } from 'next-intl';
 
 export default function PageHeader({ galasaServiceName }: { galasaServiceName: string }) {
-  const { isFeatureEnabled } = useFeatureFlags();
   const translations = useTranslations('PageHeader');
   return (
     <Theme theme="g90">
@@ -39,11 +36,8 @@ export default function PageHeader({ galasaServiceName }: { galasaServiceName: s
 
         <HeaderNavigation aria-label="Galasa menu bar navigation">
           <HeaderMenuItem href="/users">{translations('users')}</HeaderMenuItem>
-          {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS) && (
-            <HeaderMenuItem href="/test-runs">{translations('testRuns')}</HeaderMenuItem>
-          )}
+          <HeaderMenuItem href="/test-runs">{translations('testRuns')}</HeaderMenuItem>
         </HeaderNavigation>
-
         <PageHeaderMenu galasaServiceName={galasaServiceName} />
       </Header>
     </Theme>

--- a/galasa-ui/src/components/mysettings/ExperimentalFeaturesSection.tsx
+++ b/galasa-ui/src/components/mysettings/ExperimentalFeaturesSection.tsx
@@ -17,10 +17,6 @@ export default function ExperimentalFeaturesSection() {
   // Feature configuration for easier management and display
   const featureConfig = [
     {
-      key: FEATURE_FLAGS.TEST_RUNS,
-      label: translations(`features.testRunSearch`),
-    },
-    {
       key: FEATURE_FLAGS.GRAPH,
       label: translations('features.graph'),
     },

--- a/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
+++ b/galasa-ui/src/components/mysettings/ResultsTablePageSizeSetting.tsx
@@ -10,35 +10,30 @@ import { Dropdown } from '@carbon/react';
 import { useTranslations } from 'next-intl';
 import styles from '@/styles/mysettings/ResultsTablePageSizingSetting.module.css';
 import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
-import { useFeatureFlags } from '@/contexts/FeatureFlagContext';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 
 export default function ResultsTablePageSizingSetting() {
   const translations = useTranslations('ResultsTablePageSizingSetting');
-  const { isFeatureEnabled } = useFeatureFlags();
   const { defaultPageSize, setDefaultPageSize } = useResultsTablePageSize();
 
   return (
     <>
-      {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS) && (
-        <section className={styles.section}>
-          <h3 className={styles.heading}>{translations('title')}</h3>
-          <div>
-            <p className={styles.title}>{translations('description')}</p>
-            <div className={styles.dropdownContainer}>
-              <p>{translations('defaultTestRunsLabel')}</p>
-              <Dropdown
-                data-testid="custom-items-per-page-dropdown-test"
-                items={RESULTS_TABLE_PAGE_SIZES}
-                itemToString={(item: number) => item.toString()}
-                selectedItem={defaultPageSize}
-                onChange={(e: { selectedItem: number }) => setDefaultPageSize(e.selectedItem)}
-                size="md"
-              />
-            </div>
+      <section className={styles.section}>
+        <h3 className={styles.heading}>{translations('title')}</h3>
+        <div>
+          <p className={styles.title}>{translations('description')}</p>
+          <div className={styles.dropdownContainer}>
+            <p>{translations('defaultTestRunsLabel')}</p>
+            <Dropdown
+              data-testid="custom-items-per-page-dropdown-test"
+              items={RESULTS_TABLE_PAGE_SIZES}
+              itemToString={(item: number) => item.toString()}
+              selectedItem={defaultPageSize}
+              onChange={(e: { selectedItem: number }) => setDefaultPageSize(e.selectedItem)}
+              size="md"
+            />
           </div>
-        </section>
-      )}
+        </div>
+      </section>
     </>
   );
 }

--- a/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
@@ -74,6 +74,19 @@ exports[`Layout renders the web UI layout 1`] = `
                       </span>
                     </a>
                   </li>
+                  <li>
+                    <a
+                      class="cds--header__menu-item"
+                      href="/test-runs"
+                      tabindex="0"
+                    >
+                      <span
+                        class="cds--text-truncate--end"
+                      >
+                        Test runs
+                      </span>
+                    </a>
+                  </li>
                 </ul>
               </nav>
               <div
@@ -345,6 +358,19 @@ exports[`Layout renders the web UI layout 1`] = `
                       class="cds--text-truncate--end"
                     >
                       Users
+                    </span>
+                  </a>
+                </li>
+                <li>
+                  <a
+                    class="cds--header__menu-item"
+                    href="/test-runs"
+                    tabindex="0"
+                  >
+                    <span
+                      class="cds--text-truncate--end"
+                    >
+                      Test runs
                     </span>
                   </a>
                 </li>

--- a/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
+++ b/galasa-ui/src/tests/__snapshots__/layout.test.tsx.snap
@@ -94,6 +94,19 @@ exports[`Layout renders the web UI layout 1`] = `
                   </span>
                 </a>
               </li>
+              <li>
+                <a
+                  class="cds--header__menu-item"
+                  href="/test-runs"
+                  tabindex="0"
+                >
+                  <span
+                    class="cds--text-truncate--end"
+                  >
+                    Test runs
+                  </span>
+                </a>
+              </li>
             </ul>
           </nav>
           <div
@@ -121,6 +134,19 @@ exports[`Layout renders the web UI layout 1`] = `
                       class="cds--text-truncate--end"
                     >
                       Users
+                    </span>
+                  </a>
+                </li>
+                <li>
+                  <a
+                    class="cds--header__menu-item"
+                    href="/test-runs"
+                    tabindex="0"
+                  >
+                    <span
+                      class="cds--text-truncate--end"
+                    >
+                      Test runs
                     </span>
                   </a>
                 </li>
@@ -411,6 +437,19 @@ exports[`Layout renders the web UI layout 1`] = `
                 </span>
               </a>
             </li>
+            <li>
+              <a
+                class="cds--header__menu-item"
+                href="/test-runs"
+                tabindex="0"
+              >
+                <span
+                  class="cds--text-truncate--end"
+                >
+                  Test runs
+                </span>
+              </a>
+            </li>
           </ul>
         </nav>
         <div
@@ -438,6 +477,19 @@ exports[`Layout renders the web UI layout 1`] = `
                     class="cds--text-truncate--end"
                   >
                     Users
+                  </span>
+                </a>
+              </li>
+              <li>
+                <a
+                  class="cds--header__menu-item"
+                  href="/test-runs"
+                  tabindex="0"
+                >
+                  <span
+                    class="cds--text-truncate--end"
+                  >
+                    Test runs
                   </span>
                 </a>
               </li>

--- a/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
+++ b/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
@@ -59,7 +59,7 @@ test('renders the header containing the header menu', () => {
   expect(headerMenu).toBeInTheDocument();
 });
 
-test('does NOT render the "Test runs" link by default', () => {
+test('renders the "Test runs" link by default', () => {
   render(
     <FeatureFlagProvider>
       <PageHeader galasaServiceName="Galasa Service" />
@@ -67,18 +67,5 @@ test('does NOT render the "Test runs" link by default', () => {
   );
 
   const testRunsLink = screen.queryByText('Test runs');
-  expect(testRunsLink).not.toBeInTheDocument();
-});
-
-test('renders the "Test runs" link when the feature flag is enabled via prop', () => {
-  const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: true });
-
-  render(
-    <FeatureFlagProvider initialFlags={initialFlags}>
-      <PageHeader galasaServiceName="Galasa Service" />
-    </FeatureFlagProvider>
-  );
-
-  const testRunsLink = screen.getByText('Test runs');
   expect(testRunsLink).toBeInTheDocument();
 });

--- a/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
+++ b/galasa-ui/src/tests/components/headers/PageHeader.test.tsx
@@ -7,7 +7,6 @@ import { render, screen } from '@testing-library/react';
 import PageHeader from '@/components/headers/PageHeader';
 import { FeatureFlagProvider } from '@/contexts/FeatureFlagContext';
 import { useRouter } from 'next/navigation';
-import { FEATURE_FLAGS } from '@/utils/featureFlags';
 
 const mockRouter = {
   push: jest.fn(() => useRouter().push),
@@ -51,26 +50,27 @@ test('renders the header containing the header menu', () => {
   expect(headerMenu).toBeInTheDocument();
 });
 
-test('does NOT render the "Test runs" link by default', () => {
+test('renders the "Test runs" link by default', () => {
   render(
     <FeatureFlagProvider>
       <PageHeader galasaServiceName="Galasa Service" />
     </FeatureFlagProvider>
   );
 
-  const testRunsLink = screen.queryByText('Test runs');
-  expect(testRunsLink).not.toBeInTheDocument();
-});
+  // Verify "Test runs" link appears in both desktop header nav and mobile side nav
+  const testRunsLinks = screen.getAllByRole('link', { name: 'Test runs' });
+  expect(testRunsLinks).toHaveLength(2);
 
-test('renders the "Test runs" link when the feature flag is enabled via prop', () => {
-  const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: true });
+  // Both links should point to the correct href
+  testRunsLinks.forEach((link) => {
+    expect(link).toHaveAttribute('href', '/test-runs');
+  });
 
-  render(
-    <FeatureFlagProvider initialFlags={initialFlags}>
-      <PageHeader galasaServiceName="Galasa Service" />
-    </FeatureFlagProvider>
-  );
+  // Verify one is in the header navigation (desktop)
+  const headerNav = screen.getByRole('navigation', { name: 'Galasa menu bar navigation' });
+  expect(headerNav).toContainElement(testRunsLinks[0]);
 
-  const testRunsLinks = screen.getAllByText('Test runs');
-  expect(testRunsLinks.length).toBe(2);
+  // Verify one is in the side navigation (mobile)
+  const sideNav = screen.getByRole('navigation', { name: 'Side navigation' });
+  expect(sideNav).toContainElement(testRunsLinks[1]);
 });

--- a/galasa-ui/src/tests/components/mysettings/ExperimentalFeaturesSection.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ExperimentalFeaturesSection.test.tsx
@@ -15,15 +15,15 @@ jest.mock('next-intl', () => ({
       title: 'Experimental Features',
       description:
         'Early access to new features. These are experimental and subject to change or removal.',
-      'features.testRunSearch': 'Test Run searching and viewing',
+      'features.graph': 'Test Run Graphs',
     };
     return translations[key] || key;
   },
 }));
 
 describe('ExperimentalFeaturesSection', () => {
-  test('Renders correctly when "testRuns" flag is disabled: Checkbox is unchecked', () => {
-    const mockIsFeatureEnabled = (key: string) => key !== FEATURE_FLAGS.TEST_RUNS;
+  test('Renders correctly when "graph" flag is disabled: Checkbox is unchecked', () => {
+    const mockIsFeatureEnabled = (key: string) => key !== FEATURE_FLAGS.GRAPH;
 
     render(
       <FeatureFlagContext.Provider
@@ -33,13 +33,13 @@ describe('ExperimentalFeaturesSection', () => {
       </FeatureFlagContext.Provider>
     );
 
-    const checkbox = screen.getByLabelText(/Test Run/i);
+    const checkbox = screen.getByLabelText(/Test Run Graphs/i);
     expect(checkbox).not.toBeChecked();
   });
 
-  test('Renders correctly when a "testRuns" enabled: Checkbox is checked', () => {
+  test('Renders correctly when a "graph" enabled: Checkbox is checked', () => {
     const mockIsFeatureEnabled = (key: string) => {
-      return key === FEATURE_FLAGS.TEST_RUNS;
+      return key === FEATURE_FLAGS.GRAPH;
     };
 
     render(
@@ -49,7 +49,7 @@ describe('ExperimentalFeaturesSection', () => {
         <ExperimentalFeaturesSection />
       </FeatureFlagContext.Provider>
     );
-    const checkbox = screen.getByLabelText(/Test Run/i);
+    const checkbox = screen.getByLabelText(/Test Run Graphs/i);
     expect(checkbox).toBeChecked();
   });
 
@@ -64,10 +64,10 @@ describe('ExperimentalFeaturesSection', () => {
       </FeatureFlagContext.Provider>
     );
 
-    const checkbox = screen.getByRole('checkbox', { name: /Test Run/i });
+    const checkbox = screen.getByRole('checkbox', { name: /Test Run Graphs/i });
     fireEvent.click(checkbox);
 
     expect(mockToggle).toHaveBeenCalledTimes(1);
-    expect(mockToggle).toHaveBeenCalledWith(FEATURE_FLAGS.TEST_RUNS);
+    expect(mockToggle).toHaveBeenCalledWith(FEATURE_FLAGS.GRAPH);
   });
 });

--- a/galasa-ui/src/tests/components/mysettings/ExperimentalFeaturesSection.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ExperimentalFeaturesSection.test.tsx
@@ -14,15 +14,15 @@ jest.mock('next-intl', () => ({
       title: 'Experimental Features',
       description:
         'Early access to new features. These are experimental and subject to change or removal.',
-      'features.testRunSearch': 'Test Run searching and viewing',
+      'features.graph': 'Test Run Graphs',
     };
     return translations[key] || key;
   },
 }));
 
 describe('ExperimentalFeaturesSection', () => {
-  test('Renders correctly when "testRuns" flag is disabled: Checkbox is unchecked', () => {
-    const mockIsFeatureEnabled = (key: string) => key !== FEATURE_FLAGS.TEST_RUNS;
+  test('Renders correctly when "graph" flag is disabled: Checkbox is unchecked', () => {
+    const mockIsFeatureEnabled = (key: string) => key !== FEATURE_FLAGS.GRAPH;
 
     render(
       <FeatureFlagContext.Provider
@@ -32,13 +32,13 @@ describe('ExperimentalFeaturesSection', () => {
       </FeatureFlagContext.Provider>
     );
 
-    const checkbox = screen.getByLabelText(/Test Run/i);
+    const checkbox = screen.getByLabelText(/Test Run Graphs/i);
     expect(checkbox).not.toBeChecked();
   });
 
-  test('Renders correctly when a "testRuns" enabled: Checkbox is checked', () => {
+  test('Renders correctly when a "graph" enabled: Checkbox is checked', () => {
     const mockIsFeatureEnabled = (key: string) => {
-      return key === FEATURE_FLAGS.TEST_RUNS;
+      return key === FEATURE_FLAGS.GRAPH;
     };
 
     render(
@@ -48,7 +48,7 @@ describe('ExperimentalFeaturesSection', () => {
         <ExperimentalFeaturesSection />
       </FeatureFlagContext.Provider>
     );
-    const checkbox = screen.getByLabelText(/Test Run/i);
+    const checkbox = screen.getByLabelText(/Test Run Graphs/i);
     expect(checkbox).toBeChecked();
   });
 
@@ -63,10 +63,10 @@ describe('ExperimentalFeaturesSection', () => {
       </FeatureFlagContext.Provider>
     );
 
-    const checkbox = screen.getByRole('checkbox', { name: /Test Run/i });
+    const checkbox = screen.getByRole('checkbox', { name: /Test Run Graphs/i });
     fireEvent.click(checkbox);
 
     expect(mockToggle).toHaveBeenCalledTimes(1);
-    expect(mockToggle).toHaveBeenCalledWith(FEATURE_FLAGS.TEST_RUNS);
+    expect(mockToggle).toHaveBeenCalledWith(FEATURE_FLAGS.GRAPH);
   });
 });

--- a/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
@@ -79,18 +79,4 @@ describe('ResultsTablePageSizingSetting', () => {
       expect(mockSetDefaultPageSize).toHaveBeenCalledWith(50);
     });
   });
-
-  describe('when feature flag is disabled', () => {
-    beforeEach(() => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-    });
-
-    test('does not render the component', () => {
-      render(<ResultsTablePageSizingSetting />);
-
-      expect(screen.queryByText('Test Run Query Results')).toBeNull();
-      expect(screen.queryByText('Configure the number of results displayed per page.')).toBeNull();
-      expect(screen.queryByTestId('custom-items-per-page-dropdown-test')).toBeNull();
-    });
-  });
 });

--- a/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
+++ b/galasa-ui/src/tests/components/mysettings/ResultsTablePageSizingSetting.test.tsx
@@ -78,18 +78,4 @@ describe('ResultsTablePageSizingSetting', () => {
       expect(mockSetDefaultPageSize).toHaveBeenCalledWith(50);
     });
   });
-
-  describe('when feature flag is disabled', () => {
-    beforeEach(() => {
-      mockIsFeatureEnabled.mockReturnValue(false);
-    });
-
-    test('does not render the component', () => {
-      render(<ResultsTablePageSizingSetting />);
-
-      expect(screen.queryByText('Test Run Query Results')).toBeNull();
-      expect(screen.queryByText('Configure the number of results displayed per page.')).toBeNull();
-      expect(screen.queryByTestId('custom-items-per-page-dropdown-test')).toBeNull();
-    });
-  });
 });

--- a/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
+++ b/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
@@ -16,8 +16,8 @@ const TestComponent = () => {
 
   return (
     <div>
-      <p>Test Runs Enabled: {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS).toString()}</p>
-      <button onClick={() => toggleFeatureFlag(FEATURE_FLAGS.TEST_RUNS)}>Toggle Test Runs</button>
+      <p>Test Run Graphs Enabled: {isFeatureEnabled(FEATURE_FLAGS.GRAPH).toString()}</p>
+      <button onClick={() => toggleFeatureFlag(FEATURE_FLAGS.GRAPH)}>Toggle Test Run Graphs</button>
     </div>
   );
 };
@@ -40,42 +40,41 @@ describe('Feature Flags Provider and useFeatureFlags Hook', () => {
         <TestComponent />
       </FeatureFlagProvider>
     );
-    expect(screen.getByText('Test Runs Enabled: false')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: false')).toBeInTheDocument();
   });
 
   test('initializes with provided props from the server', () => {
-    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: true });
+    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.GRAPH]: true });
     render(
       <FeatureFlagProvider initialFlags={initialFlags}>
         <TestComponent />
       </FeatureFlagProvider>
     );
 
-    expect(screen.getByText('Test Runs Enabled: true')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: true')).toBeInTheDocument();
   });
 
   test('verifies feature flag toggling and updates cookie correctly', () => {
-    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: false });
+    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.GRAPH]: false });
     render(
       <FeatureFlagProvider initialFlags={initialFlags}>
         <TestComponent />
       </FeatureFlagProvider>
     );
 
-    expect(screen.getByText('Test Runs Enabled: false')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: false')).toBeInTheDocument();
 
     // Due to React's strict mode
     cookieSpy.mockClear();
 
-    const toggleButton = screen.getByText('Toggle Test Runs');
+    const toggleButton = screen.getByText('Toggle Test Run Graphs');
 
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('Test Runs Enabled: true')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: true')).toBeInTheDocument();
 
     const expectedCookieVal = JSON.stringify({
-      [FEATURE_FLAGS.TEST_RUNS]: true,
-      [FEATURE_FLAGS.GRAPH]: false,
+      [FEATURE_FLAGS.GRAPH]: true,
     });
 
     expect(cookieSpy).toHaveBeenCalledTimes(1);

--- a/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
+++ b/galasa-ui/src/tests/contexts/feature-flag-context.test.tsx
@@ -15,8 +15,8 @@ const TestComponent = () => {
 
   return (
     <div>
-      <p>Test Runs Enabled: {isFeatureEnabled(FEATURE_FLAGS.TEST_RUNS).toString()}</p>
-      <button onClick={() => toggleFeatureFlag(FEATURE_FLAGS.TEST_RUNS)}>Toggle Test Runs</button>
+      <p>Test Run Graphs Enabled: {isFeatureEnabled(FEATURE_FLAGS.GRAPH).toString()}</p>
+      <button onClick={() => toggleFeatureFlag(FEATURE_FLAGS.GRAPH)}>Toggle Test Run Graphs</button>
     </div>
   );
 };
@@ -39,42 +39,41 @@ describe('Feature Flags Provider and useFeatureFlags Hook', () => {
         <TestComponent />
       </FeatureFlagProvider>
     );
-    expect(screen.getByText('Test Runs Enabled: false')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: false')).toBeInTheDocument();
   });
 
   test('initializes with provided props from the server', () => {
-    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: true });
+    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.GRAPH]: true });
     render(
       <FeatureFlagProvider initialFlags={initialFlags}>
         <TestComponent />
       </FeatureFlagProvider>
     );
 
-    expect(screen.getByText('Test Runs Enabled: true')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: true')).toBeInTheDocument();
   });
 
   test('verifies feature flag toggling and updates cookie correctly', () => {
-    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.TEST_RUNS]: false });
+    const initialFlags = JSON.stringify({ [FEATURE_FLAGS.GRAPH]: false });
     render(
       <FeatureFlagProvider initialFlags={initialFlags}>
         <TestComponent />
       </FeatureFlagProvider>
     );
 
-    expect(screen.getByText('Test Runs Enabled: false')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: false')).toBeInTheDocument();
 
     // Due to React's strict mode
     cookieSpy.mockClear();
 
-    const toggleButton = screen.getByText('Toggle Test Runs');
+    const toggleButton = screen.getByText('Toggle Test Run Graphs');
 
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('Test Runs Enabled: true')).toBeInTheDocument();
+    expect(screen.getByText('Test Run Graphs Enabled: true')).toBeInTheDocument();
 
     const expectedCookieVal = JSON.stringify({
-      [FEATURE_FLAGS.TEST_RUNS]: true,
-      [FEATURE_FLAGS.GRAPH]: false,
+      [FEATURE_FLAGS.GRAPH]: true,
     });
 
     expect(cookieSpy).toHaveBeenCalledTimes(1);

--- a/galasa-ui/src/tests/mysettings.test.tsx
+++ b/galasa-ui/src/tests/mysettings.test.tsx
@@ -41,7 +41,7 @@ jest.mock('next-intl', () => ({
       title: 'Experimental Features',
       description:
         'Early access to new features. These are experimental and subject to change or removal.',
-      'features.testRunSearch': 'Test Run searching and viewing',
+      'features.graph': 'Test Run Graphs',
       errorTitle: 'Something went wrong!',
       errorDescription: 'Please report the problem to your Galasa Ecosystem administrator.',
     };

--- a/galasa-ui/src/tests/mysettings.test.tsx
+++ b/galasa-ui/src/tests/mysettings.test.tsx
@@ -46,7 +46,7 @@ jest.mock('next-intl', () => ({
       title: 'Experimental Features',
       description:
         'Early access to new features. These are experimental and subject to change or removal.',
-      'features.testRunSearch': 'Test Run searching and viewing',
+      'features.graph': 'Test Run Graphs',
       errorTitle: 'Something went wrong!',
       errorDescription: 'Please report the problem to your Galasa Ecosystem administrator.',
     };

--- a/galasa-ui/src/utils/featureFlags.ts
+++ b/galasa-ui/src/utils/featureFlags.ts
@@ -6,13 +6,11 @@
 
 // Centralized feature flags
 export const FEATURE_FLAGS = {
-  TEST_RUNS: 'testRuns',
   GRAPH: 'graph',
   // Add other feature flags here
 } as const;
 
 export const DEFAULT_FEATURE_FLAGS = {
-  testRuns: false,
   graph: false,
   // Add other feature flags here
 } as const;


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2434.

Removes the 'Test Runs' page from experimental features.

## Changes
- [x] Checkbox removed from My Settings page.
- [x] 'Test Runs' button is always visible in the page header.
- [x] Results Table Page Size setting is always visible in My Settings.
- [x] Unit tests test that 'Test Runs' is visible as default and experimental features tests refer to the 'Test Run Graphs' feature which is still experimental.
