### PR TITLE
Iss2444 - Fix saved queries not persisting timeframe radio selections

### DIFF
--- a/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
@@ -7,7 +7,7 @@
 
 import styles from '@/styles/test-runs/timeframe/TimeFrameContent.module.css';
 import { TimeFrameValues } from '@/utils/interfaces';
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import TimeFrameFilter from './TimeFrameFilter';
 import { dateTimeLocal2UTC, dateTimeUTC2Local } from '@/utils/timeOperations';
 import { InlineNotification } from '@carbon/react';
@@ -127,6 +127,7 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
   const [selectedToOption, setSelectedToOption] = useState<ToSelectionOptions>(
     ToSelectionOptions.now
   );
+  const isSyncingFromUrl = useRef(false);
 
   const handleValueChange = useCallback(
     (field: keyof TimeFrameValues, value: any) => {
@@ -198,6 +199,11 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
 
   // Update the isRelativeToNow state when the selectedToOption changes
   useEffect(() => {
+    // Don't update if we're currently syncing from URL to avoid circular updates
+    if (isSyncingFromUrl.current) {
+      return;
+    }
+
     const isRelativeToNow = selectedToOption === ToSelectionOptions.now;
     setValues((prevValues) => ({
       ...prevValues,
@@ -210,12 +216,16 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
   // Sync radio button selections from URL parameters when query in view changes
   useEffect(() => {
     if (values.fromOption) {
+      isSyncingFromUrl.current = true;
       setSelectedFromOption(values.fromOption as FromSelectionOptions);
     }
 
     if (values.toOption) {
+      isSyncingFromUrl.current = true;
       setSelectedToOption(values.toOption as ToSelectionOptions);
     }
+    // Reset the ref after state updates have been processed
+    isSyncingFromUrl.current = false;
   }, [values.fromOption, values.toOption]);
 
   return (

--- a/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
+++ b/galasa-ui/src/components/test-runs/timeframe/TimeFrameContent.tsx
@@ -185,29 +185,38 @@ export default function TimeFrameContent({ values, setValues }: TimeFrameContent
       // Update the state with the corrected values only if the notification is not an error
       if (validationNotification?.kind !== 'error') {
         const finalState = calculateSynchronizedState(correctedFrom, correctedTo, timezone);
-        setValues((prevValues) => ({ ...prevValues, ...finalState }));
+        setValues((prevValues) => ({
+          ...prevValues,
+          ...finalState,
+          fromOption: selectedFromOption,
+          toOption: selectedToOption,
+        }));
       }
     },
-    [values, translations, setValues, getResolvedTimeZone, selectedFromOption]
+    [values, translations, setValues, getResolvedTimeZone, selectedFromOption, selectedToOption]
   );
 
   // Update the isRelativeToNow state when the selectedToOption changes
   useEffect(() => {
     const isRelativeToNow = selectedToOption === ToSelectionOptions.now;
-    setValues((prevValues) => ({ ...prevValues, isRelativeToNow }));
-  }, [selectedToOption, setValues]);
+    setValues((prevValues) => ({
+      ...prevValues,
+      isRelativeToNow,
+      fromOption: selectedFromOption,
+      toOption: selectedToOption,
+    }));
+  }, [selectedFromOption, selectedToOption, setValues]);
 
-  // Sync selected options whenever isRelativeToNow changes (from URL or user interaction)
+  // Sync radio button selections from URL parameters when query in view changes
   useEffect(() => {
-    if (values.isRelativeToNow !== undefined) {
-      const toOption = values.isRelativeToNow
-        ? ToSelectionOptions.now
-        : ToSelectionOptions.specificToTime;
-
-      // Always sync the "To" option with isRelativeToNow
-      setSelectedToOption(toOption);
+    if (values.fromOption) {
+      setSelectedFromOption(values.fromOption as FromSelectionOptions);
     }
-  }, [values.isRelativeToNow]);
+
+    if (values.toOption) {
+      setSelectedToOption(values.toOption as ToSelectionOptions);
+    }
+  }, [values.fromOption, values.toOption]);
 
   return (
     <div className={styles.timeFrameContainer}>

--- a/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
+++ b/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
@@ -128,6 +128,8 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
     const fromParam = params.get(TEST_RUNS_QUERY_PARAMS.FROM);
     const toParam = params.get(TEST_RUNS_QUERY_PARAMS.TO);
     const durationParam = params.get(TEST_RUNS_QUERY_PARAMS.DURATION);
+    const fromOptionParam = params.get(TEST_RUNS_QUERY_PARAMS.FROM_OPTION);
+    const toOptionParam = params.get(TEST_RUNS_QUERY_PARAMS.TO_OPTION);
 
     let toDate: Date,
       fromDate: Date,
@@ -153,6 +155,8 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
     const timeframe = {
       ...calculateSynchronizedState(fromDate, toDate, timezone),
       isRelativeToNow,
+      fromOption: fromOptionParam || undefined,
+      toOption: toOptionParam || undefined,
     };
 
     // Search Criteria
@@ -284,6 +288,14 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
     } else if (timeframeValues.fromDate) {
       params.set(TEST_RUNS_QUERY_PARAMS.FROM, timeframeValues.fromDate.toISOString());
       params.set(TEST_RUNS_QUERY_PARAMS.TO, timeframeValues.toDate.toISOString());
+    }
+
+    // Radio button selections
+    if (timeframeValues.fromOption) {
+      params.set(TEST_RUNS_QUERY_PARAMS.FROM_OPTION, timeframeValues.fromOption);
+    }
+    if (timeframeValues.toOption) {
+      params.set(TEST_RUNS_QUERY_PARAMS.TO_OPTION, timeframeValues.toOption);
     }
 
     // Search Criteria

--- a/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/timeframe/TimeFrameContent.test.tsx
@@ -488,7 +488,7 @@ describe('applyTimeFrameRules', () => {
       });
     });
 
-    test('should synchronize the "To" option when the query changes to be relative to now', async () => {
+    test('should preserve radio button selections when switching between queries', async () => {
       const initialFrom = '2025-08-10T12:00:00.000Z';
       const initialTo = '2025-08-13T12:00:00.000Z';
 
@@ -503,14 +503,30 @@ describe('applyTimeFrameRules', () => {
         return (
           <>
             <TimeFrameContent values={values} setValues={setValues} />
-            {/* Add a button to simulate a query change */}
+            {/* Add a button to simulate loading a different query */}
             <button
-              role="toggle-isRelativeToNow"
+              role="load-query-with-now"
               onClick={() =>
-                setValues((prev) => ({ ...prev, isRelativeToNow: !prev.isRelativeToNow }))
+                setValues((prev) => ({
+                  ...prev,
+                  isRelativeToNow: true,
+                  toOption: ToSelectionOptions.now,
+                }))
               }
             >
-              Toggle isRelativeToNow
+              Load Query with Now
+            </button>
+            <button
+              role="load-query-with-specific"
+              onClick={() =>
+                setValues((prev) => ({
+                  ...prev,
+                  isRelativeToNow: false,
+                  toOption: ToSelectionOptions.specificToTime,
+                }))
+              }
+            >
+              Load Query with Specific Time
             </button>
           </>
         );
@@ -535,20 +551,21 @@ describe('applyTimeFrameRules', () => {
         expect(nowRadio).not.toBeChecked();
       });
 
-      // Simulate a query change
-      const toggleButton = screen.getByRole('toggle-isRelativeToNow');
-      fireEvent.click(toggleButton);
+      // Simulate loading a query that uses "Now"
+      const loadNowButton = screen.getByRole('load-query-with-now');
+      fireEvent.click(loadNowButton);
 
-      // 'To' option should have switched from specific time to 'now'
+      // 'To' option should sync to 'now' based on the loaded query
       await waitFor(() => {
         expect(nowRadio).toBeChecked();
         expect(specificToTimeRadio).not.toBeChecked();
       });
 
-      // Simulate another query change
-      fireEvent.click(toggleButton);
+      // Simulate loading a query that uses "Specific Time"
+      const loadSpecificButton = screen.getByRole('load-query-with-specific');
+      fireEvent.click(loadSpecificButton);
 
-      // 'To' option should have switched back to specific time
+      // 'To' option should sync to 'specific time' based on the loaded query
       await waitFor(() => {
         expect(specificToTimeRadio).toBeChecked();
         expect(nowRadio).not.toBeChecked();

--- a/galasa-ui/src/utils/constants/common.ts
+++ b/galasa-ui/src/utils/constants/common.ts
@@ -77,6 +77,8 @@ const TEST_RUNS_QUERY_PARAMS = {
   FROM: 'from',
   TO: 'to',
   DURATION: 'duration',
+  FROM_OPTION: 'fromOption',
+  TO_OPTION: 'toOption',
   RUN_NAME: 'runName',
   REQUESTOR: 'requestor',
   USER: 'user',

--- a/galasa-ui/src/utils/interfaces/testRuns.ts
+++ b/galasa-ui/src/utils/interfaces/testRuns.ts
@@ -42,6 +42,8 @@ export interface TimeFrameValues {
   durationHours: number;
   durationMinutes: number;
   isRelativeToNow?: boolean;
+  fromOption?: string;
+  toOption?: string;
 }
 
 export interface RunLog {


### PR DESCRIPTION
## Why?

Fixes https://github.com/galasa-dev/projectmanagement/issues/2444

### Problem
When switching between saved queries with different timeframe configurations, the radio button selections for "From" and "To" time options were not being preserved correctly, causing two problems:

1. Radio button state inconsistency: Switching between queries (e.g., "Duration + Now" to "Specific Time + Specific Time") would show incorrect radio button selections
2. Save button not enabling: The Save Query button would not enable when toggling between radio button options, even though the selection had changed

**Cause of bug:** Radio button selections were stored only in local component state and never persisted to the URL. The component relied on `isRelativeToNow` to infer which radio buttons should be selected, but this approach could not distinguish between all four valid combinations (Duration+Now, Duration+Specific, Specific+Now, Specific+Specific) and did not preserve the saved query configuration when switching between queries.

`isRelativeToNow`:
The `isRelativeToNow` property is still required to control runtime behavior (whether "To" date is dynamic new Date() or fixed) but should have never been used to populate radio button selections when switching between queries. 

## Changes
- [x] Added explicit URL parameters (fromOption and toOption) to persist radio button selections.
   - [x] Added FROM_OPTION and TO_OPTION to TEST_RUNS_QUERY_PARAMS
   - [x] Added fromOption?: string and toOption?: string to TimeFrameValues
- [x] Context now reads fromOption/toOption from URL parameters when loading queries and writes fromOption/toOption to URL parameters when state changes which is persisted with the saved query
- [x] TimeFrameContent now includes radio button selections in state updates and syncs radio buttons from URL parameters when queries load
- [x] Unit test for this scenario has been updated (verifies radio buttons sync correctly when loading queries with explicit parameters) and passing
- [x] Manual testing confirms radio buttons persist correctly across query switches
- [x] Save button enables appropriately when selections change
