### PR TITLE
James c iss2547 test runs table tags bug

### DIFF
--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -23,7 +23,7 @@ import { ColumnDefinition, DataTableHeader, DataTableRow, runStructure } from '@
 import styles from '@/styles/test-runs/TestRunsPage.module.css';
 import { TableBodyProps } from '@carbon/react/lib/components/DataTable/TableBody';
 import StatusIndicator from '../../common/StatusIndicator';
-import { SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ErrorPage from '@/app/error/page';
 import { MAX_DISPLAYABLE_TEST_RUNS, RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
@@ -135,6 +135,47 @@ export default function TestRunsTable({
     return filteredRows.slice(startIndex, endIndex);
   }, [filteredRows, currentPage, pageSize]);
 
+  // Calculate total pages for arrow key navigation
+  const totalPages = useMemo(() => {
+    return Math.ceil(filteredRows.length / pageSize);
+  }, [filteredRows.length, pageSize]);
+
+  // Handle previous page navigation
+  const handlePreviousPage = useCallback(() => {
+    if (currentPage > 1) {
+      setCurrentPage((prev) => prev - 1);
+    }
+  }, [currentPage]);
+
+  // Handle next page navigation
+  const handleNextPage = useCallback(() => {
+    if (currentPage < totalPages) {
+      setCurrentPage((prev) => prev + 1);
+    }
+  }, [currentPage, totalPages]);
+
+  // Handle arrow key navigation
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!e.repeat) {
+        switch (e.key) {
+          case 'ArrowLeft':
+            if (currentPage > 1 && !isLoading) {
+              handlePreviousPage();
+            }
+            break;
+
+          case 'ArrowRight':
+            if (currentPage < totalPages && !isLoading) {
+              handleNextPage();
+            }
+            break;
+        }
+      }
+    },
+    [currentPage, totalPages, isLoading, handlePreviousPage, handleNextPage]
+  );
+
   // Set the page back to 1 when the filter search changes
   const previousSearch = useRef(search);
   useEffect(() => {
@@ -143,6 +184,17 @@ export default function TestRunsTable({
       previousSearch.current = search;
     }
   }, [search]);
+
+  // Mount event listener to let users navigate between pages with left and right arrow keys
+  useEffect(() => {
+    if (!isLoading && filteredRows.length > 0) {
+      document.addEventListener('keydown', handleKeyDown);
+
+      return () => {
+        document.removeEventListener('keydown', handleKeyDown);
+      };
+    }
+  }, [handleKeyDown, isLoading, filteredRows.length]);
 
   if (isError) {
     return <ErrorPage />;

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -192,7 +192,7 @@ export default function TestRunsTable({
       const tagsArray = value.split(', ').sort();
       return (
         <TableCell className={styles.linkCell}>
-          <RenderTags tags={tagsArray} isDismissible={false} size="sm" />
+          <RenderTags tags={tagsArray} isDismissible={false} size="sm" truncate={true} />
           <Link href={href} prefetch={false} className={styles.linkOverlay} />
         </TableCell>
       );
@@ -286,7 +286,7 @@ export default function TestRunsTable({
               </TableToolbar>
               <Table {...getTableProps()} aria-label="test runs results table" size="lg">
                 <TableHead>
-                  <TableRow>
+                  <TableRow id={styles.tableHead}>
                     {headers.map((header) => {
                       const { key, ...headerProps } = getHeaderProps({ header });
                       return (
@@ -311,7 +311,7 @@ export default function TestRunsTable({
                               ?.value as string
                           )
                         }
-                        className={styles.clickableRow}
+                        id={styles.clickableRow}
                       >
                         {row.cells.map((cell) => (
                           <CustomCell

--- a/galasa-ui/src/components/test-runs/test-run-details/RenderTags.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/RenderTags.tsx
@@ -5,7 +5,7 @@
  */
 
 import { DismissibleTag, Tag } from '@carbon/react';
-import { useMemo } from 'react';
+import { useMemo, useRef, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { textToHexColour } from '@/utils/functions/textToHexColour';
 import styles from '@/styles/test-runs/test-run-details/RenderTags.module.css';
@@ -23,13 +23,17 @@ const RenderTags = ({
   isDismissible,
   size,
   onTagRemove,
+  truncate = false,
 }: {
   tags: string[];
   isDismissible: boolean;
   size: TagSize;
   onTagRemove?: (tag: string) => void;
+  truncate?: boolean;
 }) => {
   const translations = useTranslations('OverviewTab');
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
 
   const tagsWithColours = useMemo(
     () =>
@@ -40,42 +44,84 @@ const RenderTags = ({
     [tags]
   );
 
+  // Check if content is actually truncated
+  useEffect(() => {
+    if (truncate && containerRef.current) {
+      const isOverflowing = containerRef.current.scrollHeight > containerRef.current.clientHeight;
+      setIsTruncated(isOverflowing);
+    }
+  }, [truncate, tags]);
+
   if (tags.length === 0) {
     return <p>{translations('noTags')}</p>;
   }
 
-  return (
-    <div className={styles.tagsContainer}>
-      {tagsWithColours.map((tagWithColour: TagWithColour, index) => {
-        // Inline styles needed to grab colours from the "tagWithColour" variable.
-        const style = {
-          backgroundColor: `${tagWithColour.backgroundColour}`,
-          color: `${tagWithColour.foregroundColour}`,
-        };
+  const renderTagElements = (includeEllipsis: boolean = false) => {
+    const tagElements = tagsWithColours.map((tagWithColour: TagWithColour, index) => {
+      // Inline styles needed to grab colours from the "tagWithColour" variable.
+      const style = {
+        backgroundColor: `${tagWithColour.backgroundColour}`,
+        color: `${tagWithColour.foregroundColour}`,
+      };
 
-        return isDismissible ? (
-          <DismissibleTag
-            key={index}
-            className={styles.dismissibleTag}
-            dismissTooltipAlignment="bottom"
-            onClose={() => {
-              if (onTagRemove) {
-                onTagRemove(tagWithColour.tag);
-              }
-            }}
-            size={size}
-            text={tagWithColour.tag}
-            title={translations('removeTag')}
-            style={style}
-          />
-        ) : (
-          <Tag size={size} key={index} style={style}>
-            {tagWithColour.tag}
-          </Tag>
-        );
-      })}
-    </div>
-  );
+      return isDismissible ? (
+        <DismissibleTag
+          key={index}
+          className={styles.dismissibleTag}
+          dismissTooltipAlignment="bottom"
+          onClose={() => {
+            if (onTagRemove) {
+              onTagRemove(tagWithColour.tag);
+            }
+          }}
+          size={size}
+          text={tagWithColour.tag}
+          title={translations('removeTag')}
+          style={style}
+        />
+      ) : (
+        <Tag size={size} key={index} style={style}>
+          {tagWithColour.tag}
+        </Tag>
+      );
+    });
+
+    // Add ellipsis tag if truncated
+    if (includeEllipsis && isTruncated) {
+      tagElements.push(
+        <Tag size={size} key="ellipsis" className={styles.ellipsisTag} title={tags.join(', ')}>
+          ...
+        </Tag>
+      );
+    }
+
+    return tagElements;
+  };
+
+  if (truncate) {
+    const allTagsText = tags.join(', ');
+
+    return (
+      <div className={styles.truncatedWrapper}>
+        <div
+          ref={containerRef}
+          className={`${styles.tagsContainer} ${styles.truncated}`}
+          title={allTagsText}
+        >
+          {renderTagElements(false)}
+        </div>
+        {isTruncated && (
+          <div className={styles.ellipsisTagWrapper}>
+            <Tag size={size} className={styles.ellipsisTag} title={allTagsText}>
+              ...
+            </Tag>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return <div className={styles.tagsContainer}>{renderTagElements(false)}</div>;
 };
 
 export default RenderTags;

--- a/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
+++ b/galasa-ui/src/styles/test-runs/TestRunsPage.module.css
@@ -392,7 +392,12 @@
   transform: translateY(-50%);
 }
 
-.clickableRow {
+#tableHead,
+#clickableRow {
+  height: 56px;
+}
+
+#clickableRow {
   cursor: pointer;
 }
 

--- a/galasa-ui/src/styles/test-runs/test-run-details/RenderTags.module.css
+++ b/galasa-ui/src/styles/test-runs/test-run-details/RenderTags.module.css
@@ -20,3 +20,29 @@
 .tagsContainer :global(.cds--tag--filter):hover :global(.cds--tag__close-icon) {
   background-color: rgba(0, 0, 0, 0.2);
 }
+
+.truncatedWrapper {
+  position: relative;
+}
+
+/* Truncated tags container - limits to 2 rows with max-height of 55px */
+.tagsContainer.truncated {
+  max-height: 55px;
+  overflow: hidden;
+  cursor: help;
+  padding-right: 50px;
+}
+
+.ellipsisTagWrapper {
+  position: absolute;
+  bottom: 5px;
+  right: 0;
+  z-index: 1;
+  padding-left: 20px;
+}
+
+.ellipsisTag {
+  background-color: var(--cds-tag-background-gray, #e0e0e0);
+  color: var(--cds-text-primary, #161616);
+  font-weight: bold;
+}

--- a/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/results/TestRunsTable.test.tsx
@@ -258,6 +258,189 @@ describe('TestRunsTable Interactions', () => {
     });
     expect(screen.queryByText('Test Run 1')).not.toBeInTheDocument();
   });
+
+  test('navigates to next page when right arrow key is pressed', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Assert initial state - on page 1
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+    expect(screen.queryByText('Test Run 21')).not.toBeInTheDocument();
+
+    // Act - press right arrow key
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    // Assert - moved to page 2
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 21')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Test Run 1')).not.toBeInTheDocument();
+  });
+
+  test('navigates to previous page when left arrow key is pressed', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    const table = await screen.findByRole('table');
+
+    // Navigate to page 2 first
+    const nextPageButton = screen.getByRole('button', { name: /next page/i });
+    fireEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 21')).toBeInTheDocument();
+    });
+
+    // Act - press left arrow key
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    // Assert - moved back to page 1
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Test Run 21')).not.toBeInTheDocument();
+  });
+
+  test('does not navigate beyond first page when left arrow is pressed on page 1', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Assert initial state - on page 1
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+
+    // Act - press left arrow key on first page
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    // Assert - still on page 1
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Test Run 21')).not.toBeInTheDocument();
+  });
+
+  test('does not navigate beyond last page when right arrow is pressed on last page', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Navigate to page 2 (last page)
+    const nextPageButton = screen.getByRole('button', { name: /next page/i });
+    fireEvent.click(nextPageButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 21')).toBeInTheDocument();
+    });
+
+    // Act - press right arrow key on last page
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    // Assert - still on page 2
+    await waitFor(() => {
+      expect(screen.getByText('Test Run 21')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Test Run 1')).not.toBeInTheDocument();
+  });
+
+  test('does not navigate when arrow keys are pressed during loading', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} isLoading={true} />);
+
+    // Act - press right arrow key while loading
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+
+    // Assert - loading skeleton is still shown, no navigation occurred
+    expect(screen.getByTestId('loading-table-skeleton')).toBeInTheDocument();
+  });
+
+  test('does not navigate when arrow keys are pressed with no data', async () => {
+    // Arrange
+    render(<TestRunsTable runsList={[]} {...defaultProps} />);
+
+    // Wait for no data message
+    await screen.findByText(/No test runs were found for the selected timeframe/i);
+
+    // Act - press arrow keys
+    fireEvent.keyDown(document, { key: 'ArrowRight' });
+    fireEvent.keyDown(document, { key: 'ArrowLeft' });
+
+    // Assert - no errors, still showing no data message
+    expect(
+      screen.getByText(/No test runs were found for the selected timeframe/i)
+    ).toBeInTheDocument();
+  });
+
+  test('ignores repeated keydown events', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Assert initial state - on page 1
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+
+    // Act - press right arrow key with repeat flag
+    fireEvent.keyDown(document, { key: 'ArrowRight', repeat: true });
+
+    // Assert - should not navigate (repeat events are ignored)
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+    expect(screen.queryByText('Test Run 21')).not.toBeInTheDocument();
+  });
+
+  test('ignores non-arrow keys', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Assert initial state - on page 1
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+
+    // Act - press various non-arrow keys
+    fireEvent.keyDown(document, { key: 'Enter' });
+    fireEvent.keyDown(document, { key: 'Space' });
+    fireEvent.keyDown(document, { key: 'a' });
+
+    // Assert - still on page 1
+    expect(screen.getByText('Test Run 1')).toBeInTheDocument();
+    expect(screen.queryByText('Test Run 21')).not.toBeInTheDocument();
+  });
+
+  test('cleans up keyboard event listener on unmount', async () => {
+    // Arrange
+    const mockRuns = generateMockRuns(25);
+    const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+    const { unmount } = render(<TestRunsTable runsList={mockRuns} {...defaultProps} />);
+
+    // Wait for the table to finish loading
+    await screen.findByRole('table');
+
+    // Act - unmount the component
+    unmount();
+
+    // Assert - removeEventListener was called for keydown
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    removeEventListenerSpy.mockRestore();
+  });
 });
 
 describe('TestRunsTable rendering of TableCells', () => {


### PR DESCRIPTION
## Why?

Closes https://github.com/galasa-dev/projectmanagement/issues/2547. 

Restricts height of rendered tags to be 2 lines with an ellipsis tag if that overfills. Also added keyboard arrow navigation in case the issue rises with other columns.

## Screenshots
<img width="2488" height="1242" alt="image" src="https://github.com/user-attachments/assets/336cac8e-2464-43d1-bf59-539913c5e007" />

## Changes
- [x] Functionality
- [x] Unit tests
