### PR TITLE
Fix methods tab onlick not working

### DIFF
--- a/galasa-ui/src/components/test-runs/test-run-details/MethodsTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/MethodsTab.tsx
@@ -146,11 +146,11 @@ function MethodsTab({ methods, onMethodClick }: MethodsTabProps) {
                   return (
                     <TableRow
                       key={key}
+                      {...rowProps}
                       onClick={() =>
                         onMethodClick && onMethodClick(methodDetails[parseInt(row.id)])
                       }
                       className={styles.clickableRow}
-                      {...rowProps}
                     >
                       {/* Method name */}
                       <TableCell key={row.cells[0].id}>


### PR DESCRIPTION
## Why?

Closes https://github.com/galasa-dev/projectmanagement/issues/2567. 

Moves the rowprops to be spread above the onlick() method, solving the issue where the onclick() method `handleNavigateToLog` wasn't called

## Changes
- [x] Functionality
