### PR TITLE
Iss2566 - Uplift Node.js version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          node-version: "24.11.0"
 
       - name: Installing webui's dependencies using npm
         working-directory: ./galasa-ui

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Nodejs
         uses: actions/setup-node@v3
         with:
-          node-version: "20.10.0"
+          node-version: "24.11.0"
 
       - name: Installing webui's dependencies using npm
         working-directory: ./galasa-ui

--- a/dockerfiles/dockerfile.webui
+++ b/dockerfiles/dockerfile.webui
@@ -1,5 +1,5 @@
 # Copies build artifacts from the webui build and runs the webui application.
-FROM ghcr.io/galasa-dev/node:20.10.0-alpine
+FROM ghcr.io/galasa-dev/node:24.11.0-alpine
 
 # Some libraries may apply production optimisations when NODE_ENV is set to "production"
 ENV NODE_ENV production

--- a/galasa-ui/package-lock.json
+++ b/galasa-ui/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@tanstack/react-query": "^5.90.12",
-        "@types/node": "20.19.9",
+        "@types/node": "24.11.0",
         "@types/react": "19.2.14",
         "@types/react-dom": "19.2.3",
         "adm-zip": "^0.5.16",
@@ -4301,12 +4301,11 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
-      "license": "MIT",
+      "version": "24.11.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.11.0.tgz",
+      "integrity": "sha512-fPxQqz4VTgPI/IQ+lj9r0h+fDR66bzoeMGHp8ASee+32OSGIkeASsoZuJixsQoVef1QJbeubcPBxKk22QVoWdw==",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/pako": {
@@ -14227,10 +14226,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "license": "MIT"
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "node_modules/universalify": {
       "version": "0.2.0",

--- a/galasa-ui/package.json
+++ b/galasa-ui/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@tanstack/react-query": "^5.90.12",
-    "@types/node": "20.19.9",
+    "@types/node": "24.11.0",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",
     "adm-zip": "^0.5.16",


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2566

Uplifted version of Node.js to 24.11.0 from 20.10.0 to remove deprecation warnings from GitHub Actions and bring in line with the node version the team have been building with locally. WebUI builds cleanly locally and launches successfully on Minikube with all elements looking okay.

## Screenshot(s) of changes
N/A

## Changes
- [x] node version uplifted to 24.11.0 from 20.10.0 in the GitHub Actions workflows
- [x] Version of the node Docker image used as the base in the WebUI image also uplifted
- [x] Version uplifted also in the package.json, and package-lock.json regenerated with `npm install`
