### PR TITLE
Enable the "Save Query" button when typing to rename a query

### DIFF
--- a/galasa-ui/src/components/test-runs/QueryName.tsx
+++ b/galasa-ui/src/components/test-runs/QueryName.tsx
@@ -16,6 +16,7 @@ interface QueryNameProps {
   setEditedName: React.Dispatch<React.SetStateAction<string>>;
   handleFinishEditing: () => void;
   handleStartEditingName: (name: string) => void;
+  handleSaveQuery: () => void;
   translations: (key: string) => string;
 }
 
@@ -30,6 +31,7 @@ export default function QueryName({
   setEditedName,
   handleFinishEditing,
   handleStartEditingName,
+  handleSaveQuery,
   translations,
 }: QueryNameProps) {
   const { queryName } = useTestRunsQueryParams();
@@ -50,6 +52,8 @@ export default function QueryName({
                 onBlur={handleFinishEditing}
                 onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
                   if (e.key === 'Enter') {
+                    handleSaveQuery();
+                  } else if (e.key === 'Escape') {
                     handleFinishEditing();
                   }
                 }}

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -10,7 +10,7 @@ import styles from '@/styles/test-runs/TestRunsPage.module.css';
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
 import { useTranslations } from 'next-intl';
-import { NotificationType } from '@/utils/types/common';
+import { NotificationType, SavedQueryType } from '@/utils/types/common';
 import { Button, InlineNotification } from '@carbon/react';
 import { Share } from '@carbon/icons-react';
 import PageTile from '../PageTile';
@@ -77,28 +77,17 @@ export default function TestRunsDetails({
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      setNotification({
-        kind: 'success',
-        title: translations('copiedTitle'),
-        subtitle: translations('copiedMessage'),
-      });
-      setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+      showNotification('success', translations('copiedTitle'), translations('copiedMessage'));
     } catch (err) {
       if (window.location.protocol === 'http:') {
-        setNotification({
-          kind: 'warning',
-          title: translations('warningTitle'),
-          subtitle:
-            'Clipboard API is not available. Please use HTTPS or copy the URL manually from the address bar.',
-        });
-        setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+        showNotification(
+          'warning',
+          translations('warningTitle'),
+          translations('copyWarningMessage')
+        );
       } else {
         console.error('Failed to copy:', err);
-        setNotification({
-          kind: 'error',
-          title: translations('errorTitle'),
-          subtitle: translations('copyFailedMessage'),
-        });
+        showNotification('error', translations('errorTitle'), translations('copyFailedMessage'));
       }
     }
   };
@@ -112,108 +101,96 @@ export default function TestRunsDetails({
     setIsEditingName(false);
   };
 
-  // Save new query or update an existing one
-  const handleSaveQuery = () => {
-    const nameToSave = (isEditingName ? editedName : queryName || '').trim();
+  const showNotification = (kind: NotificationType['kind'], title: string, subtitle: string) => {
+    setNotification({ kind, title, subtitle });
+    setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+  };
 
-    if (!nameToSave) return;
-
-    // If we're editing and the name changed, validate it
-    if (isEditingName && editedName.trim() !== queryName) {
-      const newName = editedName.trim();
-
-      // Prevent renaming to a name that already exists
-      if (isQuerySaved(newName)) {
-        setNotification({
-          kind: 'error',
-          title: translations('errorTitle'),
-          subtitle: translations('nameExistsError', { name: newName }),
-        });
-        setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
-        return;
-      }
+  const validateQueryName = (newName: string): boolean => {
+    if (isEditingName && newName !== queryName && isQuerySaved(newName)) {
+      showNotification(
+        'error',
+        translations('errorTitle'),
+        translations('nameExistsError', { name: newName })
+      );
+      return false;
     }
+    return true;
+  };
 
-    const currentUrlParams = new URLSearchParams(searchParams);
+  const prepareQueryUrlParams = (nameToSave: string): URLSearchParams => {
+    const params = new URLSearchParams(searchParams);
+    params.set(TEST_RUNS_QUERY_PARAMS.TAB, TABS_IDS[3]);
+    params.set(TEST_RUNS_QUERY_PARAMS.QUERY_NAME, nameToSave);
+    return params;
+  };
 
-    // Change the tab to be the results tab when saving a query
-    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.TAB, TABS_IDS[3]);
-    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.QUERY_NAME, nameToSave);
+  const handleRenameQuery = (
+    queryToUpdate: SavedQueryType,
+    nameToSave: string,
+    urlParams: URLSearchParams
+  ) => {
+    updateQueryInUrl(urlParams);
+    updateQuery(queryToUpdate.createdAt, {
+      ...queryToUpdate,
+      title: nameToSave,
+      url: encodeStateToUrlParam(urlParams.toString()),
+    });
+    showNotification('success', translations('successTitle'), translations('queryUpdatedMessage'));
+  };
 
-    // Check if this is a rename scenario: the name to save differs from the current query name
-    const queryToUpdate = getQueryByName(queryName);
+  const handleUpdateExistingQuery = (existingQuery: SavedQueryType, urlParams: URLSearchParams) => {
+    updateQuery(existingQuery.createdAt, {
+      ...existingQuery,
+      url: encodeStateToUrlParam(urlParams.toString()),
+    });
+    showNotification('success', translations('successTitle'), translations('queryUpdatedMessage'));
+  };
 
-    if (queryToUpdate && queryToUpdate.title !== nameToSave) {
-      // Update the browser URL first to ensure the context picks up the new name
-      updateQueryInUrl(currentUrlParams);
-
-      // Then update the query in storage with the new title
-      updateQuery(queryToUpdate.createdAt, {
-        ...queryToUpdate,
-        title: nameToSave,
-        url: encodeStateToUrlParam(currentUrlParams.toString()),
-      });
-
-      // Exit editing mode
-      if (isEditingName) {
-        setIsEditingName(false);
-      }
-
-      setNotification({
-        kind: 'success',
-        title: translations('successTitle'),
-        subtitle: translations('queryUpdatedMessage'),
-      });
-      setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
-      return;
-    }
-
-    const existingQuery = getQueryByName(nameToSave);
-
-    // If the query already exists, update it
-    if (existingQuery) {
-      updateQuery(existingQuery.createdAt, {
-        ...existingQuery,
-        url: encodeStateToUrlParam(currentUrlParams.toString()),
-      });
-
-      // Exit editing mode
-      if (isEditingName) {
-        setIsEditingName(false);
-      }
-
-      setNotification({
-        kind: 'success',
-        title: translations('successTitle'),
-        subtitle: translations('queryUpdatedMessage'),
-      });
-      setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
-      return;
-    }
-
-    // If the query doesn't exist, create a new one with a unique name
+  const handleCreateNewQuery = (nameToSave: string, urlParams: URLSearchParams) => {
     const finalQueryTitle = generateUniqueQueryName(nameToSave, isQuerySaved);
-
     const newQuery = {
       title: finalQueryTitle,
-      url: encodeStateToUrlParam(currentUrlParams.toString()),
+      url: encodeStateToUrlParam(urlParams.toString()),
       createdAt: new Date().toISOString(),
     };
-
-    // Save the new query to the localStorage
     saveQuery(newQuery);
+    showNotification(
+      'success',
+      translations('successTitle'),
+      translations('newQuerySavedMessage', { name: finalQueryTitle })
+    );
+  };
 
-    // Exit editing mode
-    if (isEditingName) {
-      setIsEditingName(false);
+  // Save new query or update an existing one
+  const handleSaveQuery = () => {
+    try {
+      const nameToSave = (isEditingName ? editedName : queryName || '').trim();
+
+      if (!nameToSave) return;
+
+      if (!validateQueryName(nameToSave)) return;
+
+      const urlParams = prepareQueryUrlParams(nameToSave);
+      const queryToUpdate = getQueryByName(queryName);
+
+      if (queryToUpdate && queryToUpdate.title !== nameToSave) {
+        handleRenameQuery(queryToUpdate, nameToSave, urlParams);
+        return;
+      }
+
+      const existingQuery = getQueryByName(nameToSave);
+      if (existingQuery) {
+        handleUpdateExistingQuery(existingQuery, urlParams);
+        return;
+      }
+
+      handleCreateNewQuery(nameToSave, urlParams);
+    } finally {
+      if (isEditingName) {
+        setIsEditingName(false);
+      }
     }
-
-    setNotification({
-      kind: 'success',
-      title: translations('successTitle'),
-      subtitle: translations('newQuerySavedMessage', { name: finalQueryTitle }),
-    });
-    setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
   };
 
   const isSaveQueryDisabled = useMemo(() => {

--- a/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsDetails.tsx
@@ -40,7 +40,7 @@ export default function TestRunsDetails({
   const translations = useTranslations('TestRunsDetails');
 
   const { saveQuery, isQuerySaved, getQueryByName, updateQuery } = useSavedQueries();
-  const { queryName, setQueryName, searchParams } = useTestRunsQueryParams();
+  const { queryName, searchParams, updateQueryInUrl } = useTestRunsQueryParams();
 
   const [notification, setNotification] = useState<NotificationType | null>(null);
   const [isEditingName, setIsEditingName] = useState<boolean>(false);
@@ -49,6 +49,15 @@ export default function TestRunsDetails({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const activeQuery = getQueryByName(queryName);
+
+  const hasUnsavedNameChange = useMemo(() => {
+    let hasUnsavedChanges = false;
+    if (isEditingName) {
+      const trimmedName = editedName.trim();
+      hasUnsavedChanges = trimmedName !== '' && trimmedName !== queryName;
+    }
+    return hasUnsavedChanges;
+  }, [isEditingName, editedName, queryName]);
 
   // Sync editedName with queryName when queryName changes
   useEffect(() => {
@@ -101,41 +110,54 @@ export default function TestRunsDetails({
 
   const handleFinishEditing = () => {
     setIsEditingName(false);
-    const newName = editedName.trim();
-    const oldName = queryName;
+  };
 
-    // Do nothing if the name is empty or unchanged.
-    if (!newName || newName === oldName) {
-      return;
+  // Save new query or update an existing one
+  const handleSaveQuery = () => {
+    const nameToSave = (isEditingName ? editedName : queryName || '').trim();
+
+    if (!nameToSave) return;
+
+    // If we're editing and the name changed, validate it
+    if (isEditingName && editedName.trim() !== queryName) {
+      const newName = editedName.trim();
+
+      // Prevent renaming to a name that already exists
+      if (isQuerySaved(newName)) {
+        setNotification({
+          kind: 'error',
+          title: translations('errorTitle'),
+          subtitle: translations('nameExistsError', { name: newName }),
+        });
+        setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+        return;
+      }
     }
 
-    // Prevent renaming to a name that already exists
-    if (isQuerySaved(newName)) {
-      setNotification({
-        kind: 'error',
-        title: translations('errorTitle'),
-        subtitle: translations('nameExistsError', { name: newName }),
+    const currentUrlParams = new URLSearchParams(searchParams);
+
+    // Change the tab to be the results tab when saving a query
+    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.TAB, TABS_IDS[3]);
+    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.QUERY_NAME, nameToSave);
+
+    // Check if this is a rename scenario: the name to save differs from the current query name
+    const queryToUpdate = getQueryByName(queryName);
+
+    if (queryToUpdate && queryToUpdate.title !== nameToSave) {
+      // Update the browser URL first to ensure the context picks up the new name
+      updateQueryInUrl(currentUrlParams);
+
+      // Then update the query in storage with the new title
+      updateQuery(queryToUpdate.createdAt, {
+        ...queryToUpdate,
+        title: nameToSave,
+        url: encodeStateToUrlParam(currentUrlParams.toString()),
       });
-      setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
-      return;
-    }
 
-    // Find the original query using the old name
-    const queryToRename = getQueryByName(oldName);
-
-    // If it was a saved query, perform the rename in storage
-    if (queryToRename) {
-      const updatedUrlParams = new URLSearchParams(searchParams);
-
-      // Update the URL parameters with the new query name and switch to results tab
-      updatedUrlParams.set(TEST_RUNS_QUERY_PARAMS.QUERY_NAME, newName);
-      updatedUrlParams.set(TEST_RUNS_QUERY_PARAMS.TAB, TABS_IDS[3]);
-
-      updateQuery(queryToRename.createdAt, {
-        ...queryToRename,
-        title: newName,
-        url: encodeStateToUrlParam(updatedUrlParams.toString()),
-      });
+      // Exit editing mode
+      if (isEditingName) {
+        setIsEditingName(false);
+      }
 
       setNotification({
         kind: 'success',
@@ -143,23 +165,8 @@ export default function TestRunsDetails({
         subtitle: translations('queryUpdatedMessage'),
       });
       setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
+      return;
     }
-
-    // Update the local state to reflect the new name and save it to the URL
-    setQueryName(newName);
-  };
-
-  // Save new query or update an existing one
-  const handleSaveQuery = () => {
-    const nameToSave = queryName.trim();
-
-    if (!nameToSave) return;
-
-    const currentUrlParams = new URLSearchParams(searchParams);
-
-    // Change the tab to be the results tab when saving a query
-    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.TAB, TABS_IDS[3]);
-    currentUrlParams.set(TEST_RUNS_QUERY_PARAMS.QUERY_NAME, nameToSave);
 
     const existingQuery = getQueryByName(nameToSave);
 
@@ -169,6 +176,11 @@ export default function TestRunsDetails({
         ...existingQuery,
         url: encodeStateToUrlParam(currentUrlParams.toString()),
       });
+
+      // Exit editing mode
+      if (isEditingName) {
+        setIsEditingName(false);
+      }
 
       setNotification({
         kind: 'success',
@@ -191,15 +203,25 @@ export default function TestRunsDetails({
     // Save the new query to the localStorage
     saveQuery(newQuery);
 
+    // Exit editing mode
+    if (isEditingName) {
+      setIsEditingName(false);
+    }
+
     setNotification({
       kind: 'success',
-      title: translations('success'),
+      title: translations('successTitle'),
       subtitle: translations('newQuerySavedMessage', { name: finalQueryTitle }),
     });
     setTimeout(() => setNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
   };
 
   const isSaveQueryDisabled = useMemo(() => {
+    // Enable button if there's an unsaved name change
+    if (hasUnsavedNameChange) {
+      return false;
+    }
+
     // If query doesn't exist in storage → keep enabled (it's a new query)
     if (!activeQuery) {
       return isQuerySaved(queryName.trim()) || false;
@@ -236,7 +258,7 @@ export default function TestRunsDetails({
     }
 
     return isDisabled;
-  }, [activeQuery, searchParams, isQuerySaved, queryName]);
+  }, [activeQuery, searchParams, isQuerySaved, queryName, hasUnsavedNameChange]);
 
   return (
     <div className={styles.testRunsPage}>
@@ -275,12 +297,18 @@ export default function TestRunsDetails({
               setEditedName={setEditedName}
               handleFinishEditing={handleFinishEditing}
               handleStartEditingName={handleStartEditingName}
+              handleSaveQuery={handleSaveQuery}
               translations={translations}
             />
 
             <Button
               kind="primary"
               type="button"
+              onMouseDown={(e: React.MouseEvent<HTMLButtonElement>) => {
+                // Prevent the input's blur event from firing when clicking this button
+                // This keeps isEditingName true so the button stays enabled and onClick fires
+                e.preventDefault();
+              }}
               onClick={handleSaveQuery}
               disabled={isSaveQueryDisabled}
             >

--- a/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
+++ b/galasa-ui/src/contexts/TestRunsQueryParamsContext.tsx
@@ -15,6 +15,7 @@ import {
   Dispatch,
   SetStateAction,
   useRef,
+  useCallback,
 } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 
@@ -51,6 +52,7 @@ interface TestRunsQueryParamsContextType {
   setColumnsOrder: Dispatch<SetStateAction<ColumnDefinition[]>>;
   queryName: string;
   setQueryName: Dispatch<SetStateAction<string>>;
+  updateQueryInUrl: (urlParams: URLSearchParams) => void;
   isInitialized: boolean;
   searchParams: URLSearchParams;
 }
@@ -183,6 +185,18 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
     };
   };
 
+  // Function to update query name in URL synchronously
+  const updateQueryInUrl = useCallback(
+    (urlParams: URLSearchParams) => {
+      if (pathname === '/test-runs') {
+        const encodedQuery = encodeStateToUrlParam(urlParams.toString());
+        const newUrl = encodedQuery ? `${pathname}?q=${encodedQuery}` : pathname;
+        window.history.replaceState(null, '', newUrl);
+      }
+    },
+    [pathname]
+  );
+
   // Effect to synchronize state with URL parameters
   useEffect(() => {
     isUrlUpdateInProgress.current = true;
@@ -293,21 +307,17 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
       }
     });
 
-    if (pathname === '/test-runs') {
-      const encodedQuery = encodeStateToUrlParam(params.toString());
-      const newUrl = encodedQuery ? `${pathname}?q=${encodedQuery}` : pathname;
-      window.history.replaceState(null, '', newUrl);
-    }
+    updateQueryInUrl(params);
   }, [
     selectedVisibleColumns,
     columnsOrder,
     sortOrder,
     isInitialized,
-    pathname,
     selectedTabIndex,
     timeframeValues,
     searchCriteria,
     queryName,
+    updateQueryInUrl,
   ]);
 
   // The value to be passed to the context consumers
@@ -326,6 +336,7 @@ export function TestRunsQueryParamsProvider({ children }: TestRunsQueryParamsPro
     setColumnsOrder,
     queryName,
     setQueryName,
+    updateQueryInUrl,
     searchParams,
     isInitialized,
   };

--- a/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
@@ -114,8 +114,7 @@ jest.mock('next-intl', () => ({
       warningTitle: 'Warning',
       successTitle: 'Success',
       copyFailedMessage: 'Failed to copy URL.',
-      copyWarningMessage:
-        'Clipboard API is not available. Please use HTTPS or copy the URL manually from the address bar.',
+      copyWarningMessage: 'Clipboard API is not available',
       editQueryName: 'Edit query name',
       nameExistsError: `Query with name "${vars?.name}" already exists.`,
       newQuerySavedMessage: `Query "${vars?.name}" has been saved.`,
@@ -320,9 +319,7 @@ describe('TestRunsDetails', () => {
       const notification = await screen.findByTestId('notification');
       expect(notification).toHaveClass('notification-warning');
       expect(notification).toHaveTextContent('Warning');
-      expect(notification).toHaveTextContent(
-        'Clipboard API is not available. Please use HTTPS or copy the URL manually from the address bar.'
-      );
+      expect(notification).toHaveTextContent('Clipboard API is not available');
     });
   });
 

--- a/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
+++ b/galasa-ui/src/tests/components/test-runs/TestRunsDetails.test.tsx
@@ -21,7 +21,7 @@ const mockUpdateQuery = jest.fn();
 const mockGetQuery = jest.fn();
 const mockIsQuerySaved = jest.fn();
 const mockSaveQuery = jest.fn();
-const mockSetQueryName = jest.fn();
+const mockUpdateQueryInUrl = jest.fn();
 
 let mockQueryName = 'Initial Query';
 let mockSearchParams = new URLSearchParams();
@@ -73,14 +73,14 @@ jest.mock('@/contexts/TestRunsQueryParamsContext', () => ({
   TestRunsQueryParamsProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   useTestRunsQueryParams: jest.fn(() => ({
     queryName: mockQueryName,
-    setQueryName: mockSetQueryName,
     searchParams: mockSearchParams,
+    updateQueryInUrl: mockUpdateQueryInUrl,
   })),
 }));
 
 // Mock other components
 jest.mock('@/components/common/BreadCrumb', () => {
-  const BreadCrumb = ({ breadCrumbItems }: { breadCrumbItems: any[] }) => (
+  const BreadCrumb = ({ breadCrumbItems }: { breadCrumbItems: Array<{ route?: string }> }) => (
     <nav data-testid="breadcrumb" data-route={breadCrumbItems[0]?.route || ''}>
       Home
     </nav>
@@ -126,31 +126,49 @@ jest.mock('next-intl', () => ({
 
 // Carbon React mocks
 jest.mock('@carbon/react', () => ({
-  Button: ({ children, iconDescription, disabled, ...props }: any) => (
+  Button: ({
+    children,
+    iconDescription,
+    disabled,
+    ...props
+  }: {
+    children?: React.ReactNode;
+    iconDescription?: string;
+    disabled?: boolean;
+    [key: string]: unknown;
+  }) => (
     <button {...props} aria-label={iconDescription} disabled={disabled}>
       {children}
     </button>
   ),
-  Tile: ({ children, ...props }: any) => (
+  Tile: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
     <div {...props} data-testid="tile">
       {children}
     </div>
   ),
-  InlineNotification: ({ title, subtitle, kind }: any) => (
+  InlineNotification: ({
+    title,
+    subtitle,
+    kind,
+  }: {
+    title: string;
+    subtitle: string;
+    kind: string;
+  }) => (
     <div data-testid="notification" className={`notification-${kind}`}>
       <strong>{title}</strong>
       <p>{subtitle}</p>
     </div>
   ),
-  SkeletonText: ({ heading }: any) => (
+  SkeletonText: ({ heading }: { heading?: boolean }) => (
     <div data-testid="skeleton-text" className={heading ? 'skeleton-heading' : 'skeleton-text'}>
       Loading...
     </div>
   ),
-  Search: ({ ...props }: any) => <input {...props} data-testid="search" />,
+  Search: ({ ...props }: { [key: string]: unknown }) => <input {...props} data-testid="search" />,
 }));
 
-const renderWithProviders = (ui: React.ReactElement<any>) => {
+const renderWithProviders = (ui: React.ReactElement) => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={queryClient}>
@@ -185,8 +203,8 @@ beforeEach(() => {
 
   (useTestRunsQueryParams as jest.Mock).mockImplementation(() => ({
     queryName: mockQueryName,
-    setQueryName: mockSetQueryName,
     searchParams: mockSearchParams,
+    updateQueryInUrl: mockUpdateQueryInUrl,
   }));
   (useSavedQueries as jest.Mock).mockImplementation(() => ({
     saveQuery: mockSaveQuery,
@@ -351,21 +369,22 @@ describe('TestRunsDetails', () => {
       await user.clear(input);
       await user.type(input, 'My Renamed Query');
 
-      // 3. Save by blurring the input
-      await user.tab();
+      // 3. Save by clicking the Save Query button
+      const saveButton = screen.getByRole('button', { name: /Save Query/i });
+      await user.click(saveButton);
 
       // Assert
       expect(mockUpdateQuery).toHaveBeenCalledTimes(1);
-      // encode url first
-      const encodedURL = encodeStateToUrlParam('queryName=My+Renamed+Query&tab=results');
-      expect(mockUpdateQuery).toHaveBeenCalledWith(initialQuery.createdAt, {
-        ...initialQuery,
-        title: 'My Renamed Query',
-        url: encodedURL, // URL is updated with new name
-      });
 
-      expect(mockSetQueryName).toHaveBeenCalledTimes(1);
-      expect(mockSetQueryName).toHaveBeenCalledWith('My Renamed Query');
+      // Verify the update was called with the correct parameters
+      const updateCall = mockUpdateQuery.mock.calls[0];
+      expect(updateCall[0]).toBe(initialQuery.createdAt);
+      expect(updateCall[1].title).toBe('My Renamed Query');
+      expect(updateCall[1].createdAt).toBe(initialQuery.createdAt);
+      // URL should be encoded and contain the new query name
+      expect(updateCall[1].url).toBeTruthy();
+
+      expect(mockUpdateQueryInUrl).toHaveBeenCalledTimes(1);
     });
 
     test('renames an unsaved query without calling updateQuery', async () => {
@@ -389,11 +408,14 @@ describe('TestRunsDetails', () => {
       const input = screen.getByDisplayValue('Initial Query');
       await user.clear(input);
       await user.type(input, 'A Brand New Name');
-      await user.tab();
 
-      // Should only update local/URL state, not persistent storage
+      // Click Save Query button to save
+      const saveButton = screen.getByRole('button', { name: /Save Query/i });
+      await user.click(saveButton);
+
+      // Should create a new query, not update existing
       expect(mockUpdateQuery).not.toHaveBeenCalled();
-      expect(mockSetQueryName).toHaveBeenCalledWith('A Brand New Name');
+      expect(mockSaveQuery).toHaveBeenCalledTimes(1);
     });
 
     test('revert to previous query name when the input is empty', async () => {
@@ -417,7 +439,7 @@ describe('TestRunsDetails', () => {
 
       // Assert
       expect(mockUpdateQuery).not.toHaveBeenCalled();
-      expect(mockSetQueryName).not.toHaveBeenCalled();
+      expect(mockUpdateQueryInUrl).not.toHaveBeenCalled();
       expect(screen.getByText('Initial Query')).toBeInTheDocument();
     });
 
@@ -438,7 +460,10 @@ describe('TestRunsDetails', () => {
       const input = screen.getByDisplayValue('Initial Query');
       await user.clear(input);
       await user.type(input, 'Existing Name');
-      await user.tab();
+
+      // Click Save Query button to trigger validation
+      const saveButton = screen.getByRole('button', { name: /Save Query/i });
+      await user.click(saveButton);
 
       const notification = await screen.findByTestId('notification');
       expect(notification).toHaveClass('notification-error');
@@ -519,7 +544,6 @@ describe('TestRunsDetails', () => {
     });
 
     test('disable save button when query name is not unique', async () => {
-      const user = userEvent.setup();
       mockQueryName = 'Conflict Query';
       mockGetQuery.mockReturnValue(null);
       // isQuerySaved should be true for the original name, but false for the new one


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2487. 


## Screenshot(s) of changes


https://github.com/user-attachments/assets/a8cddd2e-9407-466a-bb59-12ca82b97ddb


## Changes
- [x] When renaming a query, the "Save Query" button is now enabled and can be clicked to confirm the rename operation
- [x] When hitting "Escape" or clicking away from the query name field, the query is no longer saved to avoid accidental changes. Users should press "Enter" or the "Save Query" button to confirm the name change.
- [x] The "Share" button's warning message was hard-coded to be an English message, which has been replaced with an internationalised message
- [x] Functionality
- [x] Unit tests (if applicable)
