### PR TITLE
Fix run log jump to top/bottom buttons occasionally stopping before reaching the top/bottom

### DIFF
--- a/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/LogTab.tsx
@@ -255,10 +255,19 @@ export default function LogTab({
 
   const scrollToTop = () => {
     if (scrollContainerRef.current) {
-      // First update the visible range to include top lines
-      setVisibleRange({ start: 0, end: Math.min(MIN_VISIBLE_LINES, visibleLines.length) });
+      const container = scrollContainerRef.current;
+      const visibleLinesEndRange = Math.min(MIN_VISIBLE_LINES, visibleLines.length);
 
-      // Wait for React to render the new range, then scroll
+      // Scroll close to the top with instant behavior
+      container.scrollTo({
+        top: visibleLinesEndRange,
+        behavior: 'instant',
+      });
+
+      // Update the visible range to include top lines
+      setVisibleRange({ start: 0, end: visibleLinesEndRange });
+
+      // After state update, scroll again with smooth behavior if preferred
       requestAnimationFrame(() => {
         if (scrollContainerRef.current) {
           scrollContainerRef.current.scrollTo({
@@ -272,10 +281,17 @@ export default function LogTab({
 
   const scrollToBottom = () => {
     if (scrollContainerRef.current) {
-      const maxScroll = visibleLines.length * LINE_HEIGHT_PIXELS;
       const container = scrollContainerRef.current;
+      const totalHeight = visibleLines.length * LINE_HEIGHT_PIXELS;
+      const maxScroll = totalHeight - container.clientHeight;
 
-      // First calculate and set the visible range for bottom lines
+      // Scroll immediately to bottom with instant behavior
+      container.scrollTo({
+        top: maxScroll,
+        behavior: 'instant',
+      });
+
+      // Calculate and set the visible range for bottom lines
       const newRange = calculateVisibleRange(
         maxScroll,
         container.clientHeight,
@@ -283,11 +299,13 @@ export default function LogTab({
       );
       setVisibleRange(newRange);
 
-      // Wait for React to render the new range, then scroll
+      // After state update, scroll again with smooth behavior if preferred
       requestAnimationFrame(() => {
         if (scrollContainerRef.current) {
+          const updatedMaxScroll =
+            scrollContainerRef.current.scrollHeight - scrollContainerRef.current.clientHeight;
           scrollContainerRef.current.scrollTo({
-            top: maxScroll,
+            top: updatedMaxScroll,
             behavior: ANIMATION_BEHAVIOUR,
           });
         }


### PR DESCRIPTION
## Why?

Related to changes in https://github.com/galasa-dev/webui/pull/290 for https://github.com/galasa-dev/projectmanagement/issues/2469

## Screenshot(s) of changes
Before:


https://github.com/user-attachments/assets/4c933cb2-58c1-4646-a639-3e49562f92fc


After:


https://github.com/user-attachments/assets/e918340c-7a40-4758-8859-e185a1bd318f


## Changes
- [x] Fixed an issue where the run log tab's jump to top/bottom buttons would stop before reaching the top/bottom of the run log.
  - Now, the buttons will cause an instant jump to a part of the run log close to the top/bottom and then scroll smoothly for a short distance depending on the user's preferred motion setting (either smooth or instant)
- [x] Functionality
