### PR TITLE
Iss2512 - Fix bug with multiple Test Runs breadcrumbs appending each refresh

### DIFF
--- a/galasa-ui/src/components/common/BreadCrumb.tsx
+++ b/galasa-ui/src/components/common/BreadCrumb.tsx
@@ -40,8 +40,7 @@ function BreadCrumb({ breadCrumbItems }: CustomBreadCrumbProps) {
 
   const renderBreadCrumbItems = (items: BreadCrumbProps[]) => {
     return items.map((item) => {
-      const translatedTitle = translations(item.title);
-      const displayText = translatedTitle.startsWith('Breadcrumb.') ? item.title : translatedTitle;
+      const displayText = translations.has(item.title) ? translations(item.title) : item.title;
 
       return (
         <BreadcrumbItem key={item.route} href={item.route}>
@@ -53,8 +52,7 @@ function BreadCrumb({ breadCrumbItems }: CustomBreadCrumbProps) {
 
   const renderOverflowItems = (items: BreadCrumbProps[]) => {
     return items.map((item) => {
-      const translatedTitle = translations(item.title);
-      const displayText = translatedTitle.startsWith('Breadcrumb.') ? item.title : translatedTitle;
+      const displayText = translations.has(item.title) ? translations(item.title) : item.title;
 
       return (
         <OverflowMenuItem

--- a/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
+++ b/galasa-ui/src/components/test-runs/TestRunsSearch.tsx
@@ -7,15 +7,19 @@ import styles from '@/styles/test-runs/TestRunsSearch.module.css';
 import { NotificationType } from '@/utils/types/common';
 import { Search } from '@carbon/react';
 import { useTranslations } from 'next-intl';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { FormEvent, useState } from 'react';
 import { TestRunsData } from '@/utils/testRuns';
 import { NOTIFICATION_VISIBLE_MILLISECS } from '@/utils/constants/common';
 import { Button } from '@carbon/react';
 import { InlineNotification } from '@carbon/react';
+import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
+import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 
 export default function TestRunsSearch() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { pushBreadCrumb } = useHistoryBreadCrumbs();
   const translations = useTranslations('TestRunsDetails');
 
   const [currentSearchInput, setCurrentSearchInput] = useState('');
@@ -45,6 +49,10 @@ export default function TestRunsSearch() {
       });
       setTimeout(() => setSearchNotification(null), NOTIFICATION_VISIBLE_MILLISECS);
     } else if (runs.length === 1) {
+      pushBreadCrumb({
+        ...TEST_RUNS,
+        route: `/test-runs?${searchParams.toString()}`,
+      });
       // Navigate to the test run details page for this run
       const runId = runs[0].runId;
       router.push(`/test-runs/${runId}`);
@@ -55,6 +63,10 @@ export default function TestRunsSearch() {
         const latestTime = new Date(latest.testStructure?.startTime ?? '').getTime();
         const currentTime = new Date(current.testStructure?.startTime ?? '').getTime();
         return currentTime > latestTime ? current : latest;
+      });
+      pushBreadCrumb({
+        ...TEST_RUNS,
+        route: `/test-runs?${searchParams.toString()}`,
       });
       const runId = latestRun.runId;
       router.push(`/test-runs/${runId}`);

--- a/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
+++ b/galasa-ui/src/components/test-runs/results/TestRunsTable.tsx
@@ -24,7 +24,7 @@ import styles from '@/styles/test-runs/TestRunsPage.module.css';
 import { TableBodyProps } from '@carbon/react/lib/components/DataTable/TableBody';
 import StatusIndicator from '../../common/StatusIndicator';
 import { SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import ErrorPage from '@/app/error/page';
 import { MAX_DISPLAYABLE_TEST_RUNS, RESULTS_TABLE_PAGE_SIZES } from '@/utils/constants/common';
 import { useTranslations } from 'next-intl';
@@ -35,6 +35,8 @@ import { getTimeframeText } from '@/utils/functions/timeFrameText';
 import useResultsTablePageSize from '@/hooks/useResultsTablePageSize';
 import Link from 'next/link';
 import RenderTags from '../test-run-details/RenderTags';
+import useHistoryBreadCrumbs from '@/hooks/useHistoryBreadCrumbs';
+import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 
 interface CustomCellProps {
   header: string;
@@ -67,6 +69,8 @@ export default function TestRunsTable({
   const { formatDate } = useDateTimeFormat();
 
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { pushBreadCrumb } = useHistoryBreadCrumbs();
 
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -229,6 +233,10 @@ export default function TestRunsTable({
 
   // Navigate to the test run details page using the runId
   const handleRowClick = (runId: string) => {
+    pushBreadCrumb({
+      ...TEST_RUNS,
+      route: `/test-runs?${searchParams.toString()}`,
+    });
     // Navigate to the test run details page
     router.push(`/test-runs/${runId}`);
   };

--- a/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
+++ b/galasa-ui/src/components/test-runs/test-run-details/TestRunDetails.tsx
@@ -44,7 +44,6 @@ import {
 } from '@/utils/constants/common';
 import { NotificationType } from '@/utils/types/common';
 import { TreeNodeData } from '@/utils/functions/artifacts';
-import { TEST_RUNS } from '@/utils/constants/breadcrumb';
 import TestRunsSearch from '../TestRunsSearch';
 import { getExistingTagObjects } from '@/actions/runsAction';
 
@@ -56,7 +55,7 @@ interface TestRunDetailsProps {
 // Type the props directly on the function's parameter
 const TestRunDetails = ({ runId, runDetailsPromise }: TestRunDetailsProps) => {
   const translations = useTranslations('TestRunDetails');
-  const { breadCrumbItems, pushBreadCrumb } = useHistoryBreadCrumbs();
+  const { breadCrumbItems } = useHistoryBreadCrumbs();
   const searchParams = useSearchParams();
   const pathname = usePathname();
 
@@ -263,15 +262,6 @@ const TestRunDetails = ({ runId, runDetailsPromise }: TestRunDetailsProps) => {
     fetchExistingTags();
   }, []);
 
-  useEffect(() => {
-    // If the 'Test Runs' breadcrumb is already in the items, skip.
-    if (breadCrumbItems.length > 1) return;
-    // Push the Test Runs URL to the breadcrumb history.
-    pushBreadCrumb({
-      ...TEST_RUNS,
-      route: `/test-runs?${searchParams.toString()}`,
-    });
-  });
 
   const handleShare = async () => {
     try {

--- a/galasa-ui/src/hooks/useHistoryBreadCrumbs.tsx
+++ b/galasa-ui/src/hooks/useHistoryBreadCrumbs.tsx
@@ -12,6 +12,39 @@ import { usePathname, useSearchParams } from 'next/navigation';
 const SESSION_STORAGE_KEY = 'breadCrumbHistory';
 
 /**
+ * Function to check if two routes are the same ignoring the 'tab' query parameter
+ * Prevents duplicate breadcrumbs when switching tabs on the same Test Run page
+ */
+function isSameRouteIgnoringTab(route1: string, route2: string): boolean {
+  if (!route1 || !route2) {
+    return false;
+  }
+
+  const [path1, query1] = route1.split('?');
+  const [path2, query2] = route2.split('?');
+
+  // Different paths = different routes
+  if (path1 !== path2) {
+    return false;
+  }
+
+  // Same path, no queries = same route
+  if (!query1 && !query2) {
+    return true;
+  }
+
+  // Remove 'tab' parameter from both query strings
+  const params1 = new URLSearchParams(query1 || '');
+  const params2 = new URLSearchParams(query2 || '');
+  params1.delete('tab');
+  params2.delete('tab');
+
+  // Compare the remaining parameters
+  const paramsMatch = params1.toString() === params2.toString();
+  return paramsMatch;
+}
+
+/**
  * Custom Hook to manage BreadCrumbs history and save it to the sessionStorage
  *
  * @returns breadCrumbItems - current bread crumb items in the history
@@ -39,7 +72,10 @@ export default function useHistoryBreadCrumbs() {
     // Avoid duplicate items (If the user refreshes the page, it will not add the same item again)
     setItems((prevItems) => {
       const newItems = [...prevItems];
-      if (newItems[newItems.length - 1]?.route !== item.route) {
+      const lastItem = newItems[newItems.length - 1];
+
+      // Check if this is a duplicate, ignoring 'tab' parameter on Test Runs page
+      if (!lastItem || !isSameRouteIgnoringTab(lastItem.route, item.route)) {
         newItems.push(item);
       }
       sessionStorage.setItem(SESSION_STORAGE_KEY, JSON.stringify(newItems));

--- a/galasa-ui/src/tests/components/common/BreadCrumb.test.tsx
+++ b/galasa-ui/src/tests/components/common/BreadCrumb.test.tsx
@@ -7,10 +7,12 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import BreadCrumb from '@/components/common/BreadCrumb';
 
-// Mock useTranslations hook to return a mock translation function
+// Mock useTranslations hook to return a mock translation function with .has() method
 jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
-    return key;
+  useTranslations: () => {
+    const translationFn = (key: string) => key;
+    translationFn.has = () => true;
+    return translationFn;
   },
 }));
 

--- a/galasa-ui/src/tests/myprofile.test.tsx
+++ b/galasa-ui/src/tests/myprofile.test.tsx
@@ -13,7 +13,7 @@ const mockUsersApi = UsersAPIApi as jest.Mock;
 jest.mock('@/generated/galasaapi');
 
 jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => {
+  useTranslations: () => {
     const translations: Record<string, string> = {
       title: 'User Details',
       loggedInAs: 'Currently logged in as:',
@@ -25,7 +25,9 @@ jest.mock('next-intl', () => ({
       errorTitle: 'Something went wrong!',
       errorDescription: 'Please report the problem to your Galasa Ecosystem administrator.',
     };
-    return translations[key] || key;
+    const translationFn = (key: string) => translations[key] || key;
+    translationFn.has = () => true;
+    return translationFn;
   },
 }));
 


### PR DESCRIPTION
## Why?

Refer to https://github.com/galasa-dev/projectmanagement/issues/2512

- This PR fixes the issue with the 'Test Runs' breadcrumb being added multiple times when refreshing the page on different tabs (overview, methods, run log, artifacts) on the Test Run Details page.
- This PR also updates the breadcrumb push to happen before navigation so the correct query parameters are included in the href of the "Test Runs" breadcrumbs. Before the push was happening after navigation so `searchParams` was empty, so every "Test Runs" breadcrumb's link was `test-runs?` i.e., the default query.
- This PR fixes console errors that were occurring when translations rightly didn't exist for Test Run Details pages. The code now calls `translations.has()` before attempting to retrieve the translation. Unit test mocks have been updated accordingly.

**Note:** this PR does not include the fix for the breadcrumbs not updating properly when using the browser's forward button. The breadcrumbs still update correctly when using the browser's back button.

## Screenshot(s) of changes
Screenshot of Test Run Details page after refreshing each tab:
<img width="614" height="669" alt="Screenshot 2026-05-28 at 16 33 20" src="https://github.com/user-attachments/assets/0be77257-24a0-43ae-af77-445c7a29eb75" />


## Changes
- [x] Functionality
- [x] Unit tests (if applicable)
